### PR TITLE
Приведение API контролов к нормальной форме

### DIFF
--- a/desktop.blocks/button/button.js
+++ b/desktop.blocks/button/button.js
@@ -41,7 +41,7 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
                 }
 
                 this.afterCurrentEvent(function() {
-                    this.trigger('gotfocus');
+                    this.trigger('focus');
                 });
 
             },
@@ -54,7 +54,7 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
                     .domElem.blur();
 
                 this.afterCurrentEvent(function() {
-                    this.trigger('lostfocus');
+                    this.trigger('blur');
                 });
 
             }

--- a/desktop.blocks/checkbox/checkbox.js
+++ b/desktop.blocks/checkbox/checkbox.js
@@ -32,7 +32,7 @@ BEM.DOM.decl('checkbox', /** @lends Checkbox.prototype */ {
                 this.setMod(this.elem('box'), 'focused', 'yes');
 
                 this.afterCurrentEvent(function() {
-                    this.trigger('gotfocus');
+                    this.trigger('focus');
                 });
             },
 
@@ -42,7 +42,7 @@ BEM.DOM.decl('checkbox', /** @lends Checkbox.prototype */ {
                 this.delMod(this.elem('box'), 'focused');
 
                 this.afterCurrentEvent(function() {
-                    this.trigger('lostfocus');
+                    this.trigger('blur');
                 });
             }
 

--- a/desktop.blocks/input/input.js
+++ b/desktop.blocks/input/input.js
@@ -80,7 +80,7 @@ BEM.DOM.decl('input', /** @lends Block.prototype */ {
                 this._focused && this._blur();
 
             this.afterCurrentEvent(function() {
-                this.trigger(focused? 'gotfocus' : 'lostfocus');
+                this.trigger(focused? 'focus' : 'blur');
             });
 
         }


### PR DESCRIPTION
Заменил название событий `got-/lost-focus` к более привычным `focus`, `blur`.

/cc @cyn Вроде ничего сломать не должно?
