### PR TITLE
9167 - [input] Курсор перед крестиком

### DIFF
--- a/common.blocks/input/__clear/input__clear.bemhtml
+++ b/common.blocks/input/__clear/input__clear.bemhtml
@@ -4,5 +4,7 @@ block input, elem clear {
 
     // &nbsp; — fixed bug FF/Linux.
     // After text selection left-click on an item that has no content, the buffer is cleared
-    content, !this.ctx.content: '&nbsp;'
+    // Delete &nbsp; for fix bug with text selection.
+    // I think we don't need anymore FF-3 on linux with X11 ;)
+    content, !this.ctx.content: ''
 }


### PR DESCRIPTION
Убран &nbsp; в common.blocks/input/__clear/input__clear.bemhtml , который решает задачу под номером 9167.
Исходя из маленькой доли FF версии < 4, тем более под Linux я счел правильным не добавлять CSS свойства которые будут являться костылями ( т.к. user-select: none; ), а просто урбать пробел который и выделялся.
