### PR TITLE
Убираем возможность выделения input__clear для touch устройств

### DIFF
--- a/touch.blocks/input/__clear/_visibility/input__clear_visibility_visible.css
+++ b/touch.blocks/input/__clear/_visibility/input__clear_visibility_visible.css
@@ -1,0 +1,5 @@
+.input__clear_visibility_visible
+{
+    -webkit-user-select: none;
+    user-select: none;
+}


### PR DESCRIPTION
На touch устройствах есть возможность выделить крестик, проблема нетривиальная, но все же проблема :)
