### PR TITLE
input: починить выставление фокуса

### DIFF
--- a/touch.blocks/input/input.js
+++ b/touch.blocks/input/input.js
@@ -2,7 +2,8 @@ BEM.DOM.decl('input', null, {
 
     live : function() {
 
-        this.liveBindTo('clear', 'leftclick tap', function() {
+        this.liveBindTo('clear', 'leftclick tap', function(e) {
+            e.preventDefault();
             this._onClearClick();
         });
 


### PR DESCRIPTION
Пропадал фокус по нажатию на крестика.
Запретил действие по умолчанию, что бы фокус оставался на месте.
