### PR TITLE
[touchpad] input: поправить отступ слева от крестика

### DIFF
--- a/touch-pad.blocks/input/__control/input__control.css
+++ b/touch-pad.blocks/input/__control/input__control.css
@@ -1,0 +1,4 @@
+.input__control
+{
+    padding-right: 0;
+}


### PR DESCRIPTION
Отступ слева от крестика слишком большой. Сделал его равным отступу справа.
