### PR TITLE
input: починить выставление фокуса

### DIFF
--- a/touch.blocks/input/input.js
+++ b/touch.blocks/input/input.js
@@ -2,12 +2,12 @@ BEM.DOM.decl('input', null, {
 
     live : function() {
 
-        this.liveBindTo('clear', 'leftclick tap', function(e) {
-            e.preventDefault();
+        this.liveBindTo('clear', 'pointerdown', function() {
             this._onClearClick();
         });
 
         return false;
 
     }
+
 });


### PR DESCRIPTION
Пропадал фокус по нажатию крестика.
Откатил запрет на действие по умолчанию при фокусе. Использовал для тачей pointerdown.
