### PR TITLE
input: починить отступ слева от крестика

### DIFF
--- a/touch-pad.blocks/input/__box/input__box.css
+++ b/touch-pad.blocks/input/__box/input__box.css
@@ -1,0 +1,4 @@
+.input__box
+{
+    padding-left: 7px;
+}

--- a/touch-pad.blocks/input/__control/input__control.css
+++ b/touch-pad.blocks/input/__control/input__control.css
@@ -1,4 +1,5 @@
 .input__control
 {
     padding-right: 0;
+    padding-left: 0;
 }

--- a/touch-pad.blocks/input/_size/input_size_m.css
+++ b/touch-pad.blocks/input/_size/input_size_m.css
@@ -1,0 +1,4 @@
+.input_size_m .input__control
+{
+    padding-left: 0;
+}

--- a/touch-pad.blocks/input/_size/input_size_s.css
+++ b/touch-pad.blocks/input/_size/input_size_s.css
@@ -1,0 +1,4 @@
+.input_size_s .input__control
+{
+    padding-left: 0;
+}


### PR DESCRIPTION
iOS 4 [touch-pad]
Починил отступ от правой границы текста до крестика.
Перенёс отступы с инпута на его обёртку.
