### PR TITLE
button: доделки после рефакторинга

### DIFF
--- a/common.blocks/button/button.js
+++ b/common.blocks/button/button.js
@@ -11,9 +11,6 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
             var disabled = this.isDisabled(),
                 domElem = this.domElem;
 
-            // состояния, поведение которых блокируется на контролах с disable
-            this._resistDisableStates = 'pressed';
-
             (this._href = domElem.attr('href')) && disabled &&
                 domElem.removeAttr('href');
 
@@ -38,14 +35,9 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
 
         'pressed' : function(modName, modVal) {
 
-            this.isDisabled() || this.trigger(modVal == 'yes' ? 'press' : 'release');
+            if (this.isDisabled()) return false;
 
-        },
-
-        '*' : function(modName) {
-
-            if(this.isDisabled() && this._resistDisableStates.indexOf(modName) > -1)
-                return false;
+            this.trigger(modVal == 'yes' ? 'press' : 'release');
 
         }
 
@@ -77,4 +69,4 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
 
     }
 
-}, /** @lends Button */ {});
+});

--- a/desktop.blocks/button/button.js
+++ b/desktop.blocks/button/button.js
@@ -8,10 +8,7 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
 
         'js' : function() {
 
-            this.__base();
-
-            // состояния, поведение которых блокируется на контролах с disable
-            this._resistDisableStates = 'hovered pressed';
+            this.__base.apply(this, arguments);
 
             this._isFocusable = 'a button'.indexOf(this.domElem[0].tagName.toLowerCase()) > -1;
         },
@@ -55,36 +52,25 @@ BEM.DOM.decl('button', /** @lends Button.prototype */ {
 
         'disabled' : function(modName, modVal) {
 
-            var disable = modVal == 'yes',
-                domElem = this.domElem;
-
-            this._href && (disable?
-                domElem.removeAttr('href') :
-                domElem.attr('href', this._href));
+            this.__base.apply(this, arguments);
 
             disable && domElem.keyup();
 
-            this.afterCurrentEvent(function() {
-                domElem.attr('disabled', disable);
-            });
+        },
+
+        'hovered' : function(modName, modVal) {
+
+            if (this.isDisabled()) return false;
+
+            modVal === '' && this.delMod('pressed');
 
         },
 
-        'hovered' : {
+        'pressed' : function(modName, modVal) {
 
-            '' : function() {
+            this.isDisabled() || this.setMod('focused', 'yes');
 
-                this.delMod('pressed');
-
-            }
-
-        },
-
-        'pressed': function(modName, modVal) {
-
-            this.setMod('focused', 'yes');
-
-            this.__base();
+            return this.__base.apply(this, arguments);
 
         }
 


### PR DESCRIPTION
починили баг связанный с порядком выполнения `onSetMod: js` и `'*'`.
Убрали блок кода `onSetMod: '*'` в пользу точечной проверки на `disable` в каждом модификаторе.
