### PR TITLE
LEGO-9802 - input: В YaBro1.5 в инпуте с крестиком клавиша Таб работает неправильно

### DIFF
--- a/desktop.blocks/input/input.js
+++ b/desktop.blocks/input/input.js
@@ -30,9 +30,12 @@ BEM.DOM.decl('input', /** @lends Block.prototype */ {
     _onBlur : function() {
         this.__base.apply(this, arguments);
 
-        var input = this.elem('control')[0];
-        if(input.selectionStart && input.selectionEnd) {
-            input.selectionStart = input.selectionEnd = 0;
+        if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+            var input = this.elem('control')[0];
+
+            if(input.selectionStart && input.selectionEnd) {
+                input.selectionStart = input.selectionEnd = 0;
+            }
         }
     },
 


### PR DESCRIPTION
LEGO-9802 - input: В YaBro1.5 в инпуте с крестиком клавиша Таб возвращает курсор в начало инпута
