### PR TITLE
LEGO-9919 - checkbox: Реализовать модификатор _autocomplete_off

### DIFF
--- a/common.blocks/checkbox/_autocomplete/checkbox_autocomplete_off.bemhtml
+++ b/common.blocks/checkbox/_autocomplete/checkbox_autocomplete_off.bemhtml
@@ -1,0 +1,5 @@
+block checkbox, mod autocomplete off, elem control, attrs: {
+   this.ctx.attrs.autocomplete = 'off';
+
+   return applyNext();
+}


### PR DESCRIPTION
Реализован модификатор _autocomplete_off. При котором в checkbox-e выставляться атрибут autocomplete: off.
