### PR TITLE
LEGO-9163 - islands-controls: [MSIE6-9] Выравнивать текст в инпутах по левому краю после потери фокуса. Убрал все изменения в коде по этому багу

### DIFF
--- a/desktop.blocks/input/input.js
+++ b/desktop.blocks/input/input.js
@@ -4,57 +4,6 @@
  */
 BEM.DOM.decl('input', /** @lends Block.prototype */ {
 
-    onSetMod : {
-
-        js : {
-
-            'inited': function() {
-
-                this.__base.apply(this, arguments);
-
-                var _this = this;
-
-                /*Исправление для ошибки при которой в IE при вводе длинной строки после потери фокуса
-                текст остается выровненным по правому краю */
-                var input = this.elem('control')[0];
-                input.attachEvent && input.attachEvent('onbeforedeactivate', this._onBeforeDeactivate);
-            }
-        }
-    },
-
-    /**
-     * Доопределяем обработчик события blur
-     * для показа начала длинной строки в FF
-     * @private
-     */
-    _onBlur : function() {
-        this.__base.apply(this, arguments);
-
-        /*Данный код необходим только для выполнения в браузере FF. Исправление для LEGO-9163*/
-        if(/firefox/i.test(navigator.userAgent)) {
-            var input = this.elem('control')[0];
-
-            if(input.selectionStart && input.selectionEnd) {
-                input.selectionStart = input.selectionEnd = 0;
-            }
-        }
-    },
-
-    /**
-     * Перед снятием фокуса делаем видимым начало длинной строки в IE
-     * @param  {Object} e объект события
-     * @private
-     */
-    _onBeforeDeactivate: function(e) {
-        var input = e.target || e.srcElement;
-
-        if(input.createTextRange) {
-            var range = input.createTextRange();
-            range.collapse(true);
-            range.select();
-        }
-    },
-
     /**
      * Нормализация установки фокуса для IE
      * @private


### PR DESCRIPTION
Выяснилось, что этот код создает ошибки для внутренних сервисов 
см комментарии к https://jira.yandex-team.ru/browse/LEGO-9163.

Было принято решение откатить фикс для этой баги.
