### PR TITLE
LEGO-10209 - check-button: Исправить логику модификаторов

### DIFF
--- a/common.blocks/check-button/check-button.js
+++ b/common.blocks/check-button/check-button.js
@@ -30,12 +30,12 @@ BEM.DOM.decl({ block: 'check-button', baseBlock: 'checkbox' }, /** @lends CheckB
     _onMouseDown : function(e) {
         e.preventDefault();
 
-        this.isChecked() || this.setMod('pressed', 'yes');
+        this.setMod('pressed', 'yes');
 
         // XXX: синхронизируем состояние кнопки и чекбокса
         this.bindToDoc('mouseup', function(e) {
             this.afterCurrentEvent(function() {
-                this.isChecked() || this.delMod('pressed');
+                this.delMod('pressed');
             })
 
             this.unbindFromDoc('mouseup');


### PR DESCRIPTION
Модификатор, который ставился на mousedown - pressed_yes не удалялся, когда мы отжимали мышь. Но так как стили ошибочно были написаны только для pressed_yes без учета модификатора checked_yes - визуально казалось что все окей. Попровил. Доработанная стилистика отправлена пулл-реквестом в islands-components c таким же cабжектом
