### PR TITLE
input__control: Preserve styled borders in i-ua_js_no mode (#129)

### DIFF
--- a/common.blocks/input/__control/input__control.css
+++ b/common.blocks/input/__control/input__control.css
@@ -12,7 +12,7 @@
 }
 
 @media all and (min-width:0px) {
-    .i-ua_js_yes .input__control
+    .input__control
     {
         padding: 0.4em 0;
 


### PR DESCRIPTION
Странно, что в i-ua_js_no у нас стремный инпут. Предлагается это исправить.
