### PR TITLE
ISL-21 — attach: исправить метод _setFile, ломающий имя файла, если в не...

### DIFF
--- a/common.blocks/attach/attach.js
+++ b/common.blocks/attach/attach.js
@@ -57,7 +57,7 @@ BEM.DOM.decl('attach', /** @lends Attach.prototype */ {
     _update : function(data) {
 
         var fileName = this._getFileByPath(this.val()),
-            prevFileName = this.elem('text').html();
+            prevFileName = this.elem('text').text();
 
         if((data && data.mode == 'clear') || (fileName && fileName !== prevFileName)) {
 
@@ -88,7 +88,7 @@ BEM.DOM.decl('attach', /** @lends Attach.prototype */ {
     _setFile : function(fileName) {
 
         this.setMod(this.elem('holder'), 'state', fileName ? '' : 'hidden');
-        this.elem('text').html(fileName || this._noFileText);
+        this.elem('text').text(fileName || this._noFileText);
     },
 
     _extensionsToMods : {


### PR DESCRIPTION
...м присутствует разметка

Заменил соответствующие вызовы $-метода html() на text()
