### PR TITLE
ISL-21 — attach: исправить метод _setFile, ломающий имя файла, если в не...

### DIFF
--- a/common.blocks/attach/attach.js
+++ b/common.blocks/attach/attach.js
@@ -91,7 +91,7 @@ DOM.decl('attach', /** @lends Attach.prototype */ {
     _setFile : function(fileName) {
         this
             .toggleMod(this.elem('holder'), 'state', 'hidden', fileName)
-            .elem('text').html(fileName || this._noFileText);
+            .elem('text').text(fileName || this._noFileText);
         return this;
     },
 


### PR DESCRIPTION
...м присутствует разметка

Заменил соответствующие вызовы $-метода html() на text()
