### PR TITLE
Radio button: allow to set 'side' property manually

### DIFF
--- a/common.blocks/radio-button/__radio/radio-button__radio.bemhtml
+++ b/common.blocks/radio-button/__radio/radio-button__radio.bemhtml
@@ -27,8 +27,9 @@ block radio-button, elem radio {
     attrs: { 'for': this._controlAttrs['id'] }
 
     mix: {
-        var side = this.isFirst() + this.isLast(),
-            controlAttrs = this._controlAttrs,
+        var mods = this.ctx.mods || {},
+            side = mods.side === undefined && this.isFirst() + this.isLast(),
+            controlAttrs = this._controlAttrs || {},
             elemMods = {};
 
         side && (elemMods.side = side > 1 ? 'both' : (this.isFirst() ? 'left' : 'right'));


### PR DESCRIPTION
Radio button doesn't allow using side property manually, so it works incorrent when we are changing context for this buttons. In that case 'isLast' and 'isFirst' functions are working incorrect, so 'side' property is adding for incorrect elements. 

This change allows to set side property manually, so 'side' property will be not be added automatically if already defined 
