### PR TITLE
Use autoprefixer to postprocess roole tech

### DIFF
--- a/.bem/make.js
+++ b/.bem/make.js
@@ -1,10 +1,11 @@
-/*global MAKE:false */
+/* global MAKE:false */
 
 var PATH = require('path'),
     environ = require('bem-environ')(__dirname);
 
 environ.extendMake(MAKE);
 
+require('bem-tools-autoprefixer')(MAKE);
 require('./nodes')(MAKE);
 
 try {
@@ -87,6 +88,7 @@ MAKE.decl('BundleNode', {
             'bemdecl.js',
             'deps.js',
             'roole',
+            'css',
             'bemhtml',
             'browser.js+bemhtml',
             'html'
@@ -112,8 +114,11 @@ MAKE.decl('BundleNode', {
         .concat(PATH.resolve(environ.PRJ_ROOT, PATH.dirname(this.getNodePrefix()), 'blocks'));
     },
 
-    'create-roole-optimizer-node' : function() {
-        return this['create-css-optimizer-node'].apply(this, arguments);
+    'create-css-node' : function(tech, bundleNode, magicNode) {
+        var source = this.getBundlePath('roole');
+        if(this.ctx.arch.hasNode(source)) {
+            return this.createAutoprefixerNode(tech, this.ctx.arch.getNode(source), bundleNode, magicNode);
+        }
     }
 
 });

--- a/.bem/make.js
+++ b/.bem/make.js
@@ -4,8 +4,8 @@ var PATH = require('path'),
     environ = require('bem-environ')(__dirname);
 
 environ.extendMake(MAKE);
+require('bem-tools-autoprefixer').extendMake(MAKE);
 
-require('bem-tools-autoprefixer')(MAKE);
 require('./nodes')(MAKE);
 
 try {
@@ -119,6 +119,45 @@ MAKE.decl('BundleNode', {
         if(this.ctx.arch.hasNode(source)) {
             return this.createAutoprefixerNode(tech, this.ctx.arch.getNode(source), bundleNode, magicNode);
         }
+    }
+
+});
+
+
+MAKE.decl('AutoprefixerNode', {
+
+    getPlatform : function() {
+        return this.output.split('.')[0];
+    },
+
+    getBrowsers : function() {
+        var platform = this.getPlatform();
+        switch(platform) {
+
+        case 'desktop':
+            return [
+                'last 2 versions',
+                'ie 10',
+                'ff 24',
+                'opera 12.16'
+            ];
+
+        case 'touch-pad':
+            return [
+                'android 4',
+                'ios 5'
+            ];
+
+        case 'touch-phone':
+            return [
+                'android 4',
+                'ios 6',
+                'ie 10'
+            ];
+
+        }
+
+        return this.__base();
     }
 
 });

--- a/.bem/nodes/bundle.js
+++ b/.bem/nodes/bundle.js
@@ -6,3 +6,4 @@ module.exports = function(registry) {
         require(environ.getLibPath('bem-core', '.bem/nodes/bundle.js'));
     } catch(e) {}
 };
+

--- a/.bem/nodes/bundle.js
+++ b/.bem/nodes/bundle.js
@@ -6,4 +6,3 @@ module.exports = function(registry) {
         require(environ.getLibPath('bem-core', '.bem/nodes/bundle.js'));
     } catch(e) {}
 };
-

--- a/.bem/techs/roole.js
+++ b/.bem/techs/roole.js
@@ -50,4 +50,3 @@ exports.techMixin = {
     }
 
 };
-

--- a/.bem/techs/roole.js
+++ b/.bem/techs/roole.js
@@ -12,16 +12,17 @@ exports.techMixin = {
 
     getBuildSuffixesMap : function() {
         return {
-            css : ['roo', 'css']
+            'roole.css' : ['roo', 'css']
         };
     },
 
-    compileBuildResult : function(res) {
+    processBuildResult : function(res) {
         var defer = Q.defer();
 
         ROOLE.compile(res, {
             filename : './',
             out : './',
+            indent : '    ',
             prefixes : []
         }, function(err, res) {
             err?
@@ -44,8 +45,9 @@ exports.techMixin = {
 
                 file.content = file.parse(res.join(''));
 
-                return this.compileBuildResult(file.process(output));
+                return this.processBuildResult(file.process(output));
             }.bind(this));
     }
 
 };
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "bem": "~0.7.2",
+    "bem-tools-autoprefixer": "~0.0.1",
     "csscomb": "~2.0.0",
     "jshint": "2.3.0",
     "jshint-groups": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "bem": "~0.7.2",
-    "bem-tools-autoprefixer": "~0.0.1",
+    "bem-tools-autoprefixer": "~0.0.2",
     "csscomb": "~2.0.0",
     "jshint": "2.3.0",
     "jshint-groups": "0.5.3",


### PR DESCRIPTION
**WIP**

Changes:
- `roole` tech now produce `.roole.css` files
- use AutoprefixerNode to post process `.roole.css` file into `.css`

fix #238 
