### PR TITLE
Specify proper dimentions for html and body tags in popup's tests

### DIFF
--- a/common.blocks/popup/popup.tests/nested.blocks/page/page.css
+++ b/common.blocks/popup/popup.tests/nested.blocks/page/page.css
@@ -1,0 +1,5 @@
+html,
+body
+{
+    height: 100%;
+}

--- a/common.blocks/popup/popup.tests/simple.blocks/page/page.css
+++ b/common.blocks/popup/popup.tests/simple.blocks/page/page.css
@@ -1,0 +1,5 @@
+html,
+body
+{
+    height: 100%;
+}


### PR DESCRIPTION
fix #300 
