### PR TITLE
Move common parts of _focused/_disabled behavior to "control" block

### DIFF
--- a/common.blocks/attach/attach.deps.js
+++ b/common.blocks/attach/attach.deps.js
@@ -1,6 +1,7 @@
 [{
     mustDeps : { block : 'i-bem', elems : ['dom', 'i18n'] },
     shouldDeps : [
+        { block : 'base-control' },
         { block : 'button' },
         { block : 'icon' },
         { elems : ['button', 'control', 'no-file', 'file'] },

--- a/common.blocks/attach/attach.js
+++ b/common.blocks/attach/attach.js
@@ -4,60 +4,20 @@
 
 modules.define(
     'attach',
-    ['i-bem__dom', 'jquery', 'BEMHTML', 'strings__escape'],
-    function(provide, BEMDOM, $, BEMHTML, escape) {
+    ['i-bem__dom', 'base-control', 'jquery', 'BEMHTML', 'strings__escape'],
+    function(provide, BEMDOM, BaseControl, $, BEMHTML, escape) {
 
 /**
  * @exports
  * @class attach
  * @bem
  */
-provide(BEMDOM.decl(this.name, /** @lends attach.prototype */{
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
-
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends attach.prototype */{
     onSetMod : {
-        'js' : {
-            'inited' : function() {
-                this._focused = false;
-            }
-        },
-
-        'focused' : {
-            'true' : function() {
-                this._focused || this._focus();
-            },
-
-            '' : function() {
-                this._focused && this._blur();
-            }
-        },
-
         'disabled' : function(modName, modVal) {
-            this.elem('control').prop(modName, !!modVal);
+            this.__base.apply(this, arguments);
             this._getButton().setMod(modName, modVal);
         }
-    },
-
-    /**
-     * Returns control value
-     * @returns {String}
-     */
-    getVal : function() {
-        return this.elem('control').val();
-    },
-
-    /**
-     * Returns control name
-     * @returns {String}
-     */
-    getName : function() {
-        return this.elem('control').attr('name');
     },
 
     /**
@@ -87,16 +47,6 @@ provide(BEMDOM.decl(this.name, /** @lends attach.prototype */{
         return this
             .dropElemCache('control file')
             ._emitChange(data);
-    },
-
-    _onFocus : function() {
-        this._focused = true;
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this._focused = false;
-        this.delMod('focused');
     },
 
     _onClearClick : function() {
@@ -139,30 +89,14 @@ provide(BEMDOM.decl(this.name, /** @lends attach.prototype */{
 
     _getButton : function() {
         return this.findBlockInside('button');
-    },
-
-    _focus : function() {
-        this.elem('control').focus();
-    },
-
-    _blur : function() {
-        this.elem('control').blur();
     }
 }, /** @lends attach */{
     live : function() {
         this
-            .liveBindTo('control', 'focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('control', 'focusout', function() {
-                this._onBlur();
-            })
-            .liveBindTo('clear', 'pointerclick', function() {
-                this._onClearClick();
-            })
-            .liveBindTo('control', 'change', function() {
-                this._onChange();
-            });
+            .liveBindTo('clear', 'pointerclick', this.prototype._onClearClick)
+            .liveBindTo('control', 'change', this.prototype._onChange);
+
+        return this.__base.apply(this, arguments);
     }
 }));
 

--- a/common.blocks/attach/attach.js
+++ b/common.blocks/attach/attach.js
@@ -10,6 +10,7 @@ modules.define(
 /**
  * @exports
  * @class attach
+ * @augments base-control
  * @bem
  */
 provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends attach.prototype */{

--- a/common.blocks/attach/attach.spec.js
+++ b/common.blocks/attach/attach.spec.js
@@ -13,6 +13,7 @@ describe('attach', function() {
         // we need to replace input[@type=file] by input[@type=text] for tests
         var input = attach.findElem('control');
         input.replaceWith('<input class="attach__control" name="' + input.attr('name')  + '"/>');
+        attach.dropElemCache();
     });
 
     afterEach(function() {

--- a/common.blocks/attach/attach.spec.js
+++ b/common.blocks/attach/attach.spec.js
@@ -1,7 +1,7 @@
 modules.define(
     'spec',
-    ['attach', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML', 'sinon'],
-    function(provide, Attach, BEMDOM, $, dom, BEMHTML, sinon) {
+    ['attach', 'i-bem__dom', 'jquery', 'BEMHTML', 'sinon'],
+    function(provide, Attach, BEMDOM, $, BEMHTML, sinon) {
 
 describe('attach', function() {
     var attach;
@@ -18,12 +18,6 @@ describe('attach', function() {
 
     afterEach(function() {
         BEMDOM.destruct(attach.domElem);
-    });
-
-    describe('name', function() {
-        it('getName should return input\'s name', function() {
-            attach.getName().should.be.equal('upload');
-        });
     });
 
     describe('value', function() {
@@ -81,41 +75,13 @@ describe('attach', function() {
         });
     });
 
-    describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            attach.elem('control').focus();
-            attach.hasMod('focused').should.be.true;
-        });
-
-        it('should delete "focused" mod on blur', function() {
-            attach.elem('control')
-                .focus()
-                .blur();
-            attach.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            attach.setMod('focused');
-            dom.containsFocus(attach.elem('control')).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            attach
-                .setMod('disabled')
-                .setMod('focused');
-            attach.hasMod('focused').should.be.false;
-        });
-    });
-
     describe('enable/disable', function() {
-        it('should enable/disable button and elem "control" according to self "disabled" mod', function() {
+        it('should enable/disable button according to self "disabled" state', function() {
             attach.setMod('disabled');
             attach.findBlockInside('button').hasMod('disabled').should.be.true;
-            attach.elem('control').prop('disabled').should.be.true;
 
             attach.delMod('disabled');
             attach.findBlockInside('button').hasMod('disabled').should.be.false;
-            attach.elem('control').prop('disabled').should.be.false;
         });
     });
 

--- a/common.blocks/base-control/base-control.deps.js
+++ b/common.blocks/base-control/base-control.deps.js
@@ -1,0 +1,12 @@
+[{
+    mustDeps : { block : 'i-bem', elems : 'dom' },
+    shouldDeps : [
+        'dom',
+        'next-tick',
+        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } }
+    ]
+}, {
+    tech : 'spec.js',
+    mustDeps : { tech : 'bemhtml' },
+    shouldDeps : 'objects'
+}]

--- a/common.blocks/base-control/base-control.js
+++ b/common.blocks/base-control/base-control.js
@@ -1,0 +1,108 @@
+/** @module base-control */
+
+modules.define(
+    'base-control',
+    ['i-bem__dom', 'dom', 'next-tick'],
+    function(provide, BEMDOM, dom, nextTick) {
+
+/**
+ * @exports
+ * @class base-control
+ * @abstract
+ * @bem
+ */
+provide(BEMDOM.decl(this.name, /** @lends base-control.prototype */{
+    beforeSetMod : {
+        'focused' : {
+            'true' : function() {
+                return !this.hasMod('disabled');
+            }
+        }
+    },
+
+    onSetMod : {
+        'js' : {
+            'inited' : function() {
+                this._focused = dom.containsFocus(this.elem('control'));
+                this._focused?
+                    // if control is already in focus, we need to set focused mod
+                    this.setMod('focused') :
+                    // if block already has focused mod, we need to focus control
+                    this.hasMod('focused') && this._focus();
+            }
+        },
+
+        'focused' : {
+            'true' : function() {
+                this._focused || this._focus();
+            },
+
+            '' : function() {
+                this._focused && this._blur();
+            }
+        },
+
+        'disabled' : {
+            '*' : function(modName, modVal) {
+                this.elem('control').prop(modName, !!modVal);
+            },
+
+            'true' : function() {
+                this.delMod('focused');
+            }
+        }
+    },
+
+    /**
+     * Returns name of control
+     * @returns {String}
+     */
+    getName : function() {
+        return this.elem('control').attr('name') || '';
+    },
+
+    /**
+     * Returns control value
+     * @returns {String}
+     */
+    getVal : function() {
+        return this.elem('control').val();
+    },
+
+    _onFocus : function() {
+        this._focused = true;
+        this.setMod('focused');
+    },
+
+    _onBlur : function() {
+        this._focused = false;
+        this.delMod('focused');
+    },
+
+    _focus : function() {
+        dom.isFocusable(this.elem('control')) && this.elem('control').focus();
+    },
+
+    _blur : function() {
+        this.elem('control').blur();
+    }
+}, /** @lends base-control */{
+    live : function() {
+        this
+            .liveBindTo('control', 'focusin', this.prototype._onFocus)
+            .liveBindTo('control', 'focusout', this.prototype._onBlur);
+
+        var focused = dom.getFocused();
+        if(focused.hasClass(this.buildClass('control'))) {
+            var _this = this; // TODO: https://github.com/bem/bem-core/issues/425
+            nextTick(function() {
+                if(focused[0] === dom.getFocused()[0]) {
+                    var block = focused.closest(_this.buildSelector());
+                    block && block.bem(_this.getName());
+                }
+            });
+        }
+    }
+}));
+
+});

--- a/common.blocks/base-control/base-control.spec.js
+++ b/common.blocks/base-control/base-control.spec.js
@@ -31,7 +31,7 @@ describe('base-control', function() {
         });
 
         it('getName should return an empty string for non inputs', function() {
-            // we're replacing `<input>` tag with
+            // NOTE: we're replacing `<input>` tag with `<span>`
             var control = baseControl.findElem('control');
             control.replaceWith('<span class="' + control[0].className + '" tabindex="0">Blah</span>');
             baseControl.dropElemCache();

--- a/common.blocks/base-control/base-control.spec.js
+++ b/common.blocks/base-control/base-control.spec.js
@@ -1,0 +1,124 @@
+modules.define(
+    'spec',
+    ['i-bem__dom', 'base-control', 'jquery', 'dom', 'objects', 'next-tick', 'BEMHTML'],
+    function(provide, BEMDOM, BaseControl, $, dom, objects, nextTick, BEMHTML) {
+
+describe('base-control', function() {
+    var bemjson = {
+            block : 'base-control',
+            js : true,
+            tag : 'span',
+            content : {
+                elem : 'control',
+                tag : 'input',
+                attrs : { name : 'blah' }
+            }
+        },
+        baseControl, control;
+
+    beforeEach(function() {
+        baseControl = buildControl(bemjson).bem('base-control');
+        control = baseControl.elem('control');
+    });
+
+    afterEach(function() {
+        BEMDOM.destruct(baseControl.domElem);
+    });
+
+    describe('name', function() {
+        it('getName should return control\'s name', function() {
+            baseControl.getName().should.be.equal('blah');
+        });
+
+        it('getName should return an empty string for non inputs', function() {
+            // we're replacing `<input>` tag with
+            var control = baseControl.findElem('control');
+            control.replaceWith('<span class="' + control[0].className + '" tabindex="0">Blah</span>');
+            baseControl.dropElemCache();
+
+            baseControl.getName().should.be.equal('');
+        });
+    });
+
+    describe('value', function() {
+        it('getVal should return control\'s value', function() {
+            control.val('blah-blah');
+            baseControl.getVal().should.be.equal('blah-blah');
+        });
+    });
+
+    describe('focus', function() {
+        it('should synchronize focus state with DOM-focus', function() {
+            baseControl.hasMod('focused').should.be.false;
+
+            control.focus();
+            baseControl.hasMod('focused').should.be.true;
+
+            control.blur();
+            baseControl.hasMod('focused').should.be.false;
+        });
+
+        it('should synchronize DOM-focus with focus state', function() {
+            baseControl.hasMod('focused').should.be.false;
+
+            baseControl.setMod('focused');
+            dom.getFocused()[0].should.be.equal(control[0]);
+
+            baseControl.delMod('focused');
+            dom.getFocused()[0].should.not.be.equal(control[0]);
+        });
+
+        it('should set focus state if DOM-focus has been set before init', function() {
+            var domElem = $(BEMHTML.apply(bemjson)).appendTo('body');
+            domElem.find('.' + BaseControl.buildClass('control')).focus();
+
+            var baseControl = BEMDOM.init(domElem).bem('base-control');
+            baseControl.hasMod('focused').should.be.true;
+
+            BEMDOM.destruct(baseControl.domElem);
+        });
+
+        it('should have DOM-focus if initialized with focus state', function() {
+            var bemJson = objects.extend({}, bemjson);
+            bemJson.mods = { focused : true };
+
+            var baseControl = buildControl(bemJson).bem('base-control');
+            dom.containsFocus(baseControl.elem('control')).should.be.true;
+            BEMDOM.destruct(baseControl.domElem);
+        });
+    });
+
+    describe('disable', function() {
+        it('should drop focus state on disabling', function() {
+            baseControl
+                .setMod('focused')
+                .setMod('disabled')
+                .hasMod('focused').should.be.false;
+        });
+
+        it('should not set focus state if disabled', function() {
+            baseControl
+                .setMod('disabled')
+                .setMod('focused')
+                .hasMod('focused').should.be.false;
+        });
+
+        it('should react on disabling', function() {
+            control.prop('disabled').should.be.false;
+
+            baseControl.setMod('disabled');
+            control.prop('disabled').should.be.true;
+
+            baseControl.delMod('disabled');
+            control.prop('disabled').should.be.false;
+        });
+    });
+});
+
+provide();
+
+function buildControl(bemjson) {
+    return BEMDOM.init($(BEMHTML.apply(bemjson)).appendTo('body'));
+}
+
+});

--- a/common.blocks/button/_type/button_type_link.js
+++ b/common.blocks/button/_type/button_type_link.js
@@ -5,21 +5,21 @@ provide(Button.decl({ modName : 'type', modVal : 'link' }, {
         'js' : {
             'inited' : function() {
                 this.__base.apply(this, arguments);
-
                 this._url = this.domElem.attr('href');
-                this.hasMod('disabled') && this.domElem.removeAttr('href');
+
+                this.hasMod('disabled') && this.elem('control').removeAttr('href');
             }
         },
 
         'disabled' : {
             'true' : function() {
                 this.__base.apply(this, arguments);
-                this.domElem.removeAttr('href');
+                this.elem('control').removeAttr('href');
             },
 
             '' : function() {
                 this.__base.apply(this, arguments);
-                this.domElem.attr('href', this._url);
+                this.elem('control').attr('href', this._url);
             }
         }
     },
@@ -39,7 +39,7 @@ provide(Button.decl({ modName : 'type', modVal : 'link' }, {
      */
     setUrl : function(url) {
         this._url = url;
-        this.hasMod('disabled') || this.domElem.attr('href', url);
+        this.hasMod('disabled') || this.elem('control').attr('href', url);
         return this;
     },
 

--- a/common.blocks/button/_type/button_type_link.js
+++ b/common.blocks/button/_type/button_type_link.js
@@ -7,19 +7,19 @@ provide(Button.decl({ modName : 'type', modVal : 'link' }, {
                 this.__base.apply(this, arguments);
                 this._url = this.domElem.attr('href');
 
-                this.hasMod('disabled') && this.elem('control').removeAttr('href');
+                this.hasMod('disabled') && this.domElem.removeAttr('href');
             }
         },
 
         'disabled' : {
             'true' : function() {
                 this.__base.apply(this, arguments);
-                this.elem('control').removeAttr('href');
+                this.domElem.removeAttr('href');
             },
 
             '' : function() {
                 this.__base.apply(this, arguments);
-                this.elem('control').attr('href', this._url);
+                this.domElem.attr('href', this._url);
             }
         }
     },
@@ -39,7 +39,7 @@ provide(Button.decl({ modName : 'type', modVal : 'link' }, {
      */
     setUrl : function(url) {
         this._url = url;
-        this.hasMod('disabled') || this.elem('control').attr('href', url);
+        this.hasMod('disabled') || this.domElem.attr('href', url);
         return this;
     },
 

--- a/common.blocks/button/button.bemhtml
+++ b/common.blocks/button/button.bemhtml
@@ -10,8 +10,10 @@ block('button')(
 
     js()(true),
 
-    attrs()(
+    // Implements `base-control`'s interface
+    mix()([{ elem : 'control' }]),
 
+    attrs()(
         // Common attributes
         function() {
             var ctx = this.ctx,

--- a/common.blocks/button/button.bh.js
+++ b/common.blocks/button/button.bh.js
@@ -3,8 +3,9 @@ module.exports = function(bh) {
     bh.match('button', function(ctx, json) {
         ctx.js(true);
 
-        // Common attributes
-        ctx.attr('role', 'button');
+        ctx
+            .attr('role', 'button') // Common attributes)
+            .mix({ elem : 'control' }); // Implements `base-control`'s interface
 
         json.tabIndex && ctx.attr('tabindex', json.tabIndex);
 

--- a/common.blocks/button/button.deps.js
+++ b/common.blocks/button/button.deps.js
@@ -1,12 +1,13 @@
 [{
-    mustDeps : { block : 'i-bem', elems : ['dom'] },
+    mustDeps : { block : 'i-bem', elems : 'dom' },
     shouldDeps : [
         {
             elems : ['text'],
             mods : { focused : 'yes', hovered : 'yes', disabled : 'yes', pressed : 'yes' }
         },
         { block : 'jquery', elem : 'event', mods : { type : 'pointer' } },
-        'functions'
+        'functions',
+        'base-control'
     ]
 },
 {

--- a/common.blocks/button/button.spec.js
+++ b/common.blocks/button/button.spec.js
@@ -1,7 +1,7 @@
 modules.define(
     'spec',
-    ['button', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML', 'sinon'],
-    function(provide, Button, BEMDOM, $, dom, BEMHTML, sinon) {
+    ['button', 'i-bem__dom', 'jquery', 'BEMHTML', 'sinon'],
+    function(provide, Button, BEMDOM, $, BEMHTML, sinon) {
 
 describe('button', function() {
     var button;
@@ -16,30 +16,6 @@ describe('button', function() {
     });
 
     describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            button.domElem.focus();
-            button.hasMod('focused').should.be.true;
-        });
-
-        it('should delete "focused" mod on blur', function() {
-            button.domElem
-                .focus()
-                .blur();
-            button.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            button.setMod('focused');
-            dom.containsFocus(button.domElem).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            button
-                .setMod('disabled')
-                .setMod('focused');
-            button.hasMod('focused').should.be.false;
-        });
-
         it('should be focused on press', function() {
             button.hasMod('focused').should.be.false;
             button.domElem.trigger('pointerpress');
@@ -96,14 +72,6 @@ describe('button', function() {
     });
 
     describe('enable/disable', function() {
-        it('should set "disabled" property according to "disabled" mod', function() {
-            button.setMod('disabled');
-            button.domElem.prop('disabled').should.be.true;
-
-            button.delMod('disabled');
-            button.domElem.prop('disabled').should.be.false;
-        });
-
         it('should remove "pressed" mod while set "disabled" mod', function() {
             button
                 .setMod('pressed')

--- a/common.blocks/checkbox/checkbox.deps.js
+++ b/common.blocks/checkbox/checkbox.deps.js
@@ -1,11 +1,12 @@
 [{
-    mustDeps : { block : 'i-bem', elems : ['dom'] },
+    mustDeps : { block : 'i-bem', elems : 'dom' },
     shouldDeps : [
         {
             elems : ['box', 'control'],
             mods : { disabled : true, focused : true, checked : true }
         },
-        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } }
+        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } },
+        'base-control'
     ]
 },
 {

--- a/common.blocks/checkbox/checkbox.js
+++ b/common.blocks/checkbox/checkbox.js
@@ -1,73 +1,11 @@
-modules.define('checkbox', ['i-bem__dom'], function(provide, BEMDOM) {
+modules.define('checkbox', ['i-bem__dom', 'base-control'], function(provide, BEMDOM, BaseControl) {
 
-provide(BEMDOM.decl(this.name, {
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
-
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, {
     onSetMod : {
-        'js' : {
-            'inited' : function() {
-                this._focused = false;
-            }
-        },
-
         'checked' : function(modName, modVal) {
             this.elem('control').prop(modName, modVal);
             this.emit('change');
-        },
-
-        'disabled' : function(modName, modVal) {
-            this.elem('control').prop(modName, modVal);
-        },
-
-        'focused' : {
-            'true' : function() {
-                this._focused || this._focus();
-            },
-
-            '' : function() {
-                this._focused && this._blur();
-            }
         }
-    },
-
-    /**
-     * Returns control value
-     * @returns {String}
-     */
-    getVal : function() {
-        return this.elem('control').val();
-    },
-
-    /**
-     * Returns name of control
-     * @returns {String}
-     */
-    getName : function() {
-        return this.elem('control').attr('name');
-    },
-
-    _focus : function() {
-        this.elem('control').focus();
-    },
-
-    _blur : function() {
-        this.elem('control').blur();
-    },
-
-    _onFocus : function() {
-        this._focused = true;
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this._focused = false;
-        this.delMod('focused');
     },
 
     _onChange : function() {
@@ -75,16 +13,8 @@ provide(BEMDOM.decl(this.name, {
     }
 }, {
     live : function() {
-        this
-            .liveBindTo('focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('focusout', function() {
-                this._onBlur();
-            })
-            .liveBindTo('change', function() {
-                this._onChange();
-            });
+        this.liveBindTo('control', 'change', this.prototype._onChange);
+        return this.__base.apply(this, arguments);
     }
 }));
 

--- a/common.blocks/checkbox/checkbox.js
+++ b/common.blocks/checkbox/checkbox.js
@@ -1,6 +1,16 @@
+/**
+ * @module checkbox
+ */
+
 modules.define('checkbox', ['i-bem__dom', 'base-control'], function(provide, BEMDOM, BaseControl) {
 
-provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, {
+/**
+ * @exports
+ * @class checkbox
+ * @augments base-control
+ * @bem
+ */
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends checkbox.prototype */{
     onSetMod : {
         'checked' : function(modName, modVal) {
             this.elem('control').prop(modName, modVal);
@@ -11,7 +21,7 @@ provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, {
     _onChange : function() {
         this.setMod('checked', this.elem('control').prop('checked'));
     }
-}, {
+}, /** @lends checkbox */{
     live : function() {
         this.liveBindTo('control', 'change', this.prototype._onChange);
         return this.__base.apply(this, arguments);

--- a/common.blocks/checkbox/checkbox.spec.js
+++ b/common.blocks/checkbox/checkbox.spec.js
@@ -1,7 +1,7 @@
 modules.define(
     'spec',
-    ['checkbox', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML', 'sinon'],
-    function(provide, Checkbox, BEMDOM, $, dom, BEMHTML, sinon) {
+    ['checkbox', 'i-bem__dom', 'jquery', 'BEMHTML', 'sinon'],
+    function(provide, Checkbox, BEMDOM, $, BEMHTML, sinon) {
 
 describe('checkbox', function() {
     var checkbox;
@@ -13,8 +13,8 @@ describe('checkbox', function() {
                 val : 'val',
                 label : 'label'
             }))
-                .appendTo('body'))
-                .bem('checkbox');
+            .appendTo('body'))
+            .bem('checkbox');
     }
 
     beforeEach(function() {
@@ -23,12 +23,6 @@ describe('checkbox', function() {
 
     afterEach(function() {
         BEMDOM.destruct(checkbox.domElem);
-    });
-
-    describe('value', function() {
-        it('should return value of "control" elem', function() {
-            checkbox.getVal().should.be.equal('val');
-        });
     });
 
     describe('checked', function() {
@@ -62,51 +56,6 @@ describe('checkbox', function() {
                 .setMod('checked');
 
             spy.should.have.been.calledOnce;
-        });
-    });
-
-    describe('disabled', function() {
-        it('should properly update "control" elem "disabled" attr', function() {
-            checkbox
-                .setMod('disabled')
-                .elem('control').prop('disabled').should.be.true;
-
-            checkbox
-                .delMod('disabled')
-                .elem('control').prop('disabled').should.be.false;
-        });
-    });
-
-    describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            checkbox.elem('control').focus();
-            checkbox.hasMod('focused').should.be.true;
-        });
-
-        it('should not have "focused" mod on blur', function() {
-            checkbox.elem('control')
-                .focus()
-                .blur();
-            checkbox.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            checkbox.setMod('focused');
-            dom.containsFocus(checkbox.elem('control')).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            checkbox
-                .setMod('disabled')
-                .setMod('focused');
-            checkbox.hasMod('focused').should.be.false;
-        });
-
-        it('should be blured after "focused" mod unset', function() {
-            checkbox
-                .setMod('focused')
-                .delMod('focused');
-            dom.containsFocus(checkbox.elem('control')).should.be.false;
         });
     });
 });

--- a/common.blocks/input/input.deps.js
+++ b/common.blocks/input/input.deps.js
@@ -1,11 +1,11 @@
 [{
-    mustDeps : { block : 'i-bem', elem : 'dom' },
+    mustDeps : { block : 'i-bem', elems : 'dom' },
     shouldDeps : [
         {
             mods : ['disabled', 'focused'],
             elems : ['box', 'control']
         },
-        'dom'
+        'base-control'
     ]
 },
 {

--- a/common.blocks/input/input.js
+++ b/common.blocks/input/input.js
@@ -1,48 +1,29 @@
-modules.define('input', ['i-bem__dom', 'dom'], function(provide, BEMDOM, dom) {
+/**
+ * @module input
+ */
 
-provide(BEMDOM.decl(this.name, {
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
+modules.define('input', ['i-bem__dom', 'base-control'], function(provide, BEMDOM, BaseControl) {
 
+/**
+ * @exports
+ * @class input
+ * @augments base-control
+ * @bem
+ */
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends input.prototype */{
     onSetMod : {
         'js' : {
             'inited' : function() {
-                var control = this.elem('control');
-
-                this._val = control.val();
-                this._focused = dom.containsFocus(control);
-
-                this._focused?
-                    // if control is already in focus, we need to set focused mod
-                    this.setMod('focused') :
-                    // if block already has focused mod, we need to focus control
-                    this.hasMod('focused') && this._focus();
+                this.__base.apply(this, arguments);
+                this._val = this.elem('control').val();
             }
-        },
-
-        'focused' : {
-            'true' : function() {
-                this._focused || this._focus();
-            },
-
-            '' : function() {
-                this._focused && this._blur();
-            }
-        },
-
-        'disabled' : function(modName, modVal) {
-            this.elem('control').prop(modName, !!modVal);
         }
     },
 
     /**
      * Returns control value
      * @returns {String}
+     * @override
      */
     getVal : function() {
         return this._val;
@@ -67,43 +48,10 @@ provide(BEMDOM.decl(this.name, {
         }
 
         return this;
-    },
-
-    /**
-     * Returns name of control
-     * @returns {String}
-     */
-    getName : function() {
-        return this.elem('control').attr('name');
-    },
-
-    _onFocus : function() {
-        this._focused = true;
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this._focused = false;
-        this.delMod('focused');
-    },
-
-    _focus : function() {
-        this.elem('control').focus();
-    },
-
-    _blur : function() {
-        this.elem('control').blur();
     }
 }, {
     live : function() {
-        this
-            .liveBindTo('control', 'focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('control', 'focusout', function() {
-                this._onBlur();
-            });
-
+        this.__base.apply(this, arguments);
         return false;
     }
 }));

--- a/common.blocks/input/input.spec.js
+++ b/common.blocks/input/input.spec.js
@@ -1,7 +1,7 @@
 modules.define(
     'spec',
-    ['input', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML', 'sinon'],
-    function(provide, Input, BEMDOM, $, dom, BEMHTML, sinon) {
+    ['input', 'i-bem__dom', 'jquery', 'BEMHTML', 'sinon'],
+    function(provide, Input, BEMDOM, $, BEMHTML, sinon) {
 
 describe('input', function() {
     var input;
@@ -12,63 +12,6 @@ describe('input', function() {
 
     afterEach(function() {
         BEMDOM.destruct(input.domElem);
-    });
-
-    describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            input.elem('control').focus();
-            input.hasMod('focused').should.be.true;
-        });
-
-        it('should not have "focused" mod on blur', function() {
-            input.elem('control')
-                .focus()
-                .blur();
-            input.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            input.setMod('focused');
-            dom.containsFocus(input.elem('control')).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            input
-                .setMod('disabled')
-                .setMod('focused');
-            input.hasMod('focused').should.be.false;
-        });
-
-        it('should set "focused" mod if input have been focused before init', function() {
-            var domElem = $(BEMHTML.apply({ block : 'input' })).appendTo('body');
-            domElem.find('.input__control').focus();
-            var input = BEMDOM.init(domElem).bem('input');
-            input.hasMod('focused').should.be.true;
-            BEMDOM.destruct(input.domElem);
-        });
-
-        it('should focus control if input already has focused mod before init', function() {
-            var input = buildInput({ block : 'input', mods : { focused : true } });
-            dom.containsFocus(input.elem('control')).should.be.true;
-            BEMDOM.destruct(input.domElem);
-        });
-
-        it('should be blured after "focused" mod unset', function() {
-            input
-                .setMod('focused')
-                .delMod('focused');
-            dom.containsFocus(input.elem('control')).should.be.false;
-        });
-    });
-
-    describe('enable/disable', function() {
-        it('should set "disabled" property according to "disabled" mod', function() {
-            input.setMod('disabled');
-            input.elem('control').prop('disabled').should.be.true;
-
-            input.delMod('disabled');
-            input.elem('control').prop('disabled').should.be.false;
-        });
     });
 
     describe('val', function() {

--- a/common.blocks/link/_pseudo/link_pseudo.js
+++ b/common.blocks/link/_pseudo/link_pseudo.js
@@ -1,7 +1,7 @@
 modules.define('link', function(provide, Link) {
 
 provide(Link.decl({ modName : 'pseudo', modVal : true }, {
-    _onClick : function(e) {
+    _onPointerClick : function(e) {
         e.preventDefault();
         this.__base.apply(this, arguments);
     }

--- a/common.blocks/link/link.bemhtml
+++ b/common.blocks/link/link.bemhtml
@@ -3,6 +3,9 @@ block('link')(
 
     js()(true),
 
+    // Implements `base-control`'s interface
+    mix()([{ elem : 'control' }]),
+
     attrs()(function() {
         var ctx = this.ctx,
             attrs = {

--- a/common.blocks/link/link.bh.js
+++ b/common.blocks/link/link.bh.js
@@ -3,7 +3,8 @@ module.exports = function(bh) {
     bh.match('link', function(ctx, json) {
         ctx
             .tag('a')
-            .js(true);
+            .js(true)
+            .mix({ elem : 'control' });
 
         var attrs = {
                 tabindex : json.tabIndex

--- a/common.blocks/link/link.deps.js
+++ b/common.blocks/link/link.deps.js
@@ -10,8 +10,5 @@
 },
 {
     tech : 'spec.js',
-    mustDeps : [
-        { tech : 'bemhtml', block : 'link' },
-        { tech : 'js', block : 'dom' }
-    ]
+    mustDeps : { tech : 'bemhtml', block : 'link' }
 }]

--- a/common.blocks/link/link.deps.js
+++ b/common.blocks/link/link.deps.js
@@ -4,7 +4,8 @@
     ],
     shouldDeps : [
         { mod : 'disabled' },
-        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } }
+        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } },
+        'base-control'
     ]
 },
 {

--- a/common.blocks/link/link.js
+++ b/common.blocks/link/link.js
@@ -1,57 +1,25 @@
-modules.define('link', ['i-bem__dom'], function(provide, BEMDOM) {
+/**
+ * @module link
+ */
 
-provide(BEMDOM.decl(this.name, {
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
+modules.define('link', ['i-bem__dom', 'base-control'], function(provide, BEMDOM, BaseControl) {
 
-    onSetMod : {
-        'focused' : {
-            'true' : function() {
-                this.domElem.focus();
-            },
-
-            '' : function() {
-                this.domElem.blur();
-            }
-        },
-
-        'disabled' : {
-            'true' : function() {
-                this.delMod('focused');
-            }
-        }
-    },
-
-    _onClick : function(e) {
+/**
+ * @exports
+ * @class link
+ * @augments base-control
+ * @bem
+ */
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends link.prototype */{
+    _onPointerClick : function(e) {
         this.hasMod('disabled')?
             e.preventDefault() :
             this.emit('click');
-    },
-
-    _onFocus : function() {
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this.delMod('focused');
     }
-}, {
+}, /** @lends link */{
     live : function() {
-        this
-            .liveBindTo('pointerclick', function(e) {
-                this._onClick(e);
-            })
-            .liveBindTo('focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('focusout', function() {
-                this._onBlur();
-            });
+        this.liveBindTo('control', 'pointerclick', this.prototype._onPointerClick);
+        return this.__base.apply(this, arguments);
     }
 }));
 

--- a/common.blocks/link/link.spec.js
+++ b/common.blocks/link/link.spec.js
@@ -1,7 +1,7 @@
 modules.define(
     'spec',
-    ['link', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML', 'sinon'],
-    function(provide, Link, BEMDOM, $, dom, BEMHTML, sinon) {
+    ['link', 'i-bem__dom', 'jquery', 'BEMHTML', 'sinon'],
+    function(provide, Link, BEMDOM, $, BEMHTML, sinon) {
 
 describe('link', function() {
     var link;
@@ -38,32 +38,6 @@ describe('link', function() {
 
         e.isDefaultPrevented().should.be.true;
         spy.should.not.have.been.called;
-    });
-
-    describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            link.domElem.focus();
-            link.hasMod('focused').should.be.true;
-        });
-
-        it('should delete "focused" mod on blur', function() {
-            link.domElem
-                .focus()
-                .blur();
-            link.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            link.setMod('focused');
-            dom.containsFocus(link.domElem).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            link
-                .setMod('disabled')
-                .setMod('focused')
-                .hasMod('focused').should.be.false;
-        });
     });
 });
 

--- a/common.blocks/menu-item/_type/menu-item_type_link.js
+++ b/common.blocks/menu-item/_type/menu-item_type_link.js
@@ -33,10 +33,7 @@ provide(MenuItem.decl({ modName : 'type', modVal : 'link' }, {
     }
 }, {
     live : function() {
-        this.liveBindTo('focusin', function() {
-            this._onFocus();
-        });
-
+        this.liveBindTo('focusin', this.prototype._onFocus);
         return this.__base.apply(this, arguments);
     }
 }));

--- a/common.blocks/menu-item/menu-item.js
+++ b/common.blocks/menu-item/menu-item.js
@@ -45,9 +45,7 @@ provide(BEMDOM.decl(this.name, /** @lends menu-item.prototype */{
     }
 }, /** @lends menu-item */{
     live : function() {
-        this.liveBindTo('pointerclick', function() {
-            this._onPointerClick();
-        });
+        this.liveBindTo('pointerclick', this.prototype._onPointerClick);
     }
 }));
 

--- a/common.blocks/menu/_select/menu_select.js
+++ b/common.blocks/menu/_select/menu_select.js
@@ -34,6 +34,7 @@ provide(Menu.decl({ modName : 'select' }, /** @lends menu.prototype */{
     /**
      * Returns menu value
      * @returns {*}
+     * @override
      */
     getVal : function() {
         if(!this._isValValid) {

--- a/common.blocks/menu/menu.bemhtml
+++ b/common.blocks/menu/menu.bemhtml
@@ -8,7 +8,8 @@ block('menu')(
         this.mods.disabled || (attrs.tabindex = 0);
         return attrs;
     }),
-    js()(true)
+    js()(true),
+    mix()([{ elem : 'control' }])
 )
 
 block('menu-item').match(this._menuTheme).def()(function() {

--- a/common.blocks/menu/menu.deps.js
+++ b/common.blocks/menu/menu.deps.js
@@ -1,8 +1,7 @@
 [{
     mustDeps : { block : 'i-bem', elems : ['dom'] },
     shouldDeps : [
-        'dom',
-        'next-tick',
+        'base-control',
         'menu-item',
         { mods : { focused : true } }
     ]

--- a/common.blocks/menu/menu.js
+++ b/common.blocks/menu/menu.js
@@ -42,9 +42,10 @@ provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends m
 
         'disabled' : function(modName, modVal) {
             this.__base.apply(this, arguments);
+            var control = this.elem('control');
             modVal?
-                this.elem('control').removeAttr('tabindex') :
-                this.elem('control').attr('tabindex', 0);
+                control.removeAttr('tabindex') :
+                control.attr('tabindex', 0);
         }
     },
 

--- a/common.blocks/menu/menu.js
+++ b/common.blocks/menu/menu.js
@@ -4,55 +4,47 @@
 
 modules.define(
     'menu',
-    ['i-bem__dom', 'dom', 'next-tick', 'menu-item'],
-    function(provide, BEMDOM, dom, nextTick) {
+    ['i-bem__dom', 'base-control', 'menu-item'],
+    function(provide, BEMDOM, BaseControl) {
 
 /**
  * @exports
  * @class menu
+ * @augments base-control
  * @bem
  */
-provide(BEMDOM.decl(this.name, /** @lends menu.prototype */{
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
-
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends menu.prototype */{
     onSetMod : {
         'js' : {
             'inited' : function() {
+                this.__base.apply(this, arguments);
                 this._hoveredItem = null;
                 this._items = null;
 
                 this.hasMod('focused') && this.bindToDoc('keydown', this._onKeyDown);
-
-                this._focused = dom.containsFocus(this.domElem);
-                this._focused?
-                    // if control is already in focus, we need to set focused mod
-                    this.setMod('focused') :
-                    // if block already has focused mod, we need to focus control
-                    this.hasMod('focused') && this._focus();
             }
         },
 
         'focused' : {
             'true' : function() {
-                this.bindToDoc('keydown', this._onKeyDown);
-                this._focused || this._focus();
+                this
+                    .bindToDoc('keydown', this._onKeyDown)
+                    .__base.apply(this, arguments);
             },
 
             '' : function() {
-                this.unbindFromDoc('keydown', this._onKeyDown);
-                this._focused && this._blur();
+                this
+                    .unbindFromDoc('keydown', this._onKeyDown)
+                    .__base.apply(this, arguments);
                 this._hoveredItem && this._hoveredItem.delMod('hovered');
             }
         },
 
         'disabled' : function(modName, modVal) {
-            this.domElem.attr('tabindex', modVal? -1 : 0);
+            this.__base.apply(this, arguments);
+            modVal?
+                this.elem('control').removeAttr('tabindex') :
+                this.elem('control').attr('tabindex', 0);
         }
     },
 
@@ -106,24 +98,6 @@ provide(BEMDOM.decl(this.name, /** @lends menu.prototype */{
 
             items[nextIdx].setMod('hovered');
         }
-    },
-
-    _onFocus : function() {
-        this._focused = true;
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this._focused = false;
-        this.delMod('focused');
-    },
-
-    _focus : function() {
-        this.domElem.focus();
-    },
-
-    _blur : function() {
-        this.domElem.blur();
     }
 }, /** @lends menu */{
     live : function() {
@@ -133,21 +107,9 @@ provide(BEMDOM.decl(this.name, /** @lends menu.prototype */{
             })
             .liveInitOnBlockInsideEvent('click', 'menu-item', function(e) {
                 this._onItemClick(e.target);
-            })
-            .liveBindTo('focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('focusout', function() {
-                this._onBlur();
             });
 
-        var focused = dom.getFocused();
-        if(focused.hasClass(this.buildClass())) {
-            var _this = this; // TODO: https://github.com/bem/bem-core/issues/425
-            nextTick(function() {
-                focused[0] === dom.getFocused()[0] && focused.bem(_this.getName());
-            });
-        }
+        return this.__base.apply(this, arguments);
     }
 }));
 

--- a/common.blocks/menu/menu.spec.js
+++ b/common.blocks/menu/menu.spec.js
@@ -1,7 +1,9 @@
 modules.define(
     'spec',
-    ['menu', 'i-bem__dom', 'jquery', 'dom', 'sinon', 'BEMHTML'],
-    function(provide, Menu, BEMDOM, $, dom, sinon, BEMHTML) {
+    ['menu', 'i-bem__dom', 'jquery', 'sinon', 'chai', 'BEMHTML'],
+    function(provide, Menu, BEMDOM, $, sinon, chai, BEMHTML) {
+
+var expect = chai.expect;
 
 describe('menu', function() {
     var menu, menuItems;
@@ -36,6 +38,19 @@ describe('menu', function() {
         BEMDOM.destruct(menu.domElem);
     });
 
+    describe('disable', function() {
+        it('should remove "tabindex" attribute on disable', function() {
+            var control = menu.elem('control');
+            control.attr('tabindex').should.be.equal('0');
+
+            menu.setMod('disabled');
+            expect(control.attr('tabindex')).to.be.undefined;
+
+            menu.delMod('disabled');
+            control.attr('tabindex').should.be.equal('0');
+        });
+    });
+
     describe('hover on items', function() {
         it('should unhover previous hovered item', function() {
             menuItems[0].setMod('hovered');
@@ -68,39 +83,8 @@ describe('menu', function() {
 
     });
 
-    describe('focus', function() {
-        it('should mirror focus state with DOM-focus (which can be appeared before init)', function() {
-            var menuDomElem = $(BEMHTML.apply({ block : 'menu' })).appendTo('body').focus(),
-                menu = BEMDOM.init(menuDomElem).bem('menu');
-            menu.hasMod('focused').should.be.true;
-            BEMDOM.destruct(menu.domElem);
-        });
-
-        it('should mirror DOM-focus with focus state on init', function() {
-            var menu = buildMenu({ block : 'menu', mods : { focused : true } });
-            dom.getFocused()[0].should.be.equal(menu.domElem[0]);
-            BEMDOM.destruct(menu.domElem);
-        });
-
-        it('should synchronize focus state with DOM-focus', function() {
-            menu.hasMod('focused').should.be.false;
-            menu.domElem.focus();
-            menu.hasMod('focused').should.be.true;
-            menu.domElem.blur();
-            menu.hasMod('focused').should.be.false;
-        });
-
-        it('should synchronize DOM-focus with focus state', function() {
-            menu.hasMod('focused').should.be.false;
-            menu.setMod('focused');
-            dom.getFocused()[0].should.be.equal(menu.domElem[0]);
-            menu.delMod('focused');
-            dom.getFocused()[0].should.not.be.equal(menu.domElem[0]);
-        });
-    });
-
     describe('events', function() {
-        it('should emit event on item click', function() {
+        it('should emit "item-click" event on item click', function() {
             var spy = sinon.spy();
             menu.on('item-click', spy);
             menuItems[1].emit('click');

--- a/common.blocks/radio-option/radio-option.deps.js
+++ b/common.blocks/radio-option/radio-option.deps.js
@@ -5,7 +5,8 @@
             elems : ['box', 'control'],
             mods : { disabled : true, checked : true, focused : true }
         },
-        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } }
+        { block : 'jquery', elem : 'event', mods : { type : 'pointer' } },
+        'base-control'
     ]
 },
 {

--- a/common.blocks/radio-option/radio-option.js
+++ b/common.blocks/radio-option/radio-option.js
@@ -1,89 +1,29 @@
-modules.define('radio-option', ['i-bem__dom'], function(provide, BEMDOM) {
+/**
+ * @module radio-option
+ */
 
-provide(BEMDOM.decl(this.name, {
-    beforeSetMod : {
-        'focused' : {
-            'true' : function() {
-                return !this.hasMod('disabled');
-            }
-        }
-    },
+modules.define('radio-option', ['i-bem__dom', 'base-control'], function(provide, BEMDOM, BaseControl) {
 
+/**
+ * @exports
+ * @class radio-option
+ * @augments base-control
+ * @bem
+ */
+provide(BEMDOM.decl({ block : this.name, baseBlock : BaseControl }, /** @lends radio-option.prototype */{
     onSetMod : {
-        'js' : {
-            'inited' : function() {
-                this._focused = false;
-            }
-        },
-
         'checked' : function(modName, modVal) {
             this.elem('control').prop(modName, modVal);
-        },
-
-        'disabled' : function(modName, modVal) {
-            this.elem('control').prop(modName, modVal);
-        },
-
-        'focused' : {
-            'true' : function() {
-                this._focused || this._focus();
-            },
-
-            '' : function() {
-                this._focused && this._blur();
-            }
         }
-    },
-
-    /**
-     * Returns control value
-     * @returns {String}
-     */
-    getVal : function() {
-        return this.elem('control').val();
-    },
-
-    /**
-     * Returns name of control
-     * @returns {String}
-     */
-    getName : function() {
-        return this.elem('control').attr('name');
-    },
-
-    _focus : function() {
-        this.elem('control').focus();
-    },
-
-    _blur : function() {
-        this.elem('control').blur();
-    },
-
-    _onFocus : function() {
-        this._focused = true;
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this._focused = false;
-        this.delMod('focused');
     },
 
     _onPointerClick : function() {
         this.hasMod('disabled') || this.setMod('checked');
     }
-}, {
+}, /** @lends radio-option */{
     live : function() {
-        this
-            .liveBindTo('focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('focusout', function() {
-                this._onBlur();
-            })
-            .liveBindTo('pointerclick', function() {
-                this._onPointerClick();
-            });
+        this.liveBindTo('pointerclick', this.prototype._onPointerClick);
+        return this.__base.apply(this, arguments);
     }
 }));
 

--- a/common.blocks/radio-option/radio-option.spec.js
+++ b/common.blocks/radio-option/radio-option.spec.js
@@ -25,12 +25,6 @@ describe('radio-option', function() {
         BEMDOM.destruct(radioOption.domElem);
     });
 
-    describe('value', function() {
-        it('should return value of "control" elem', function() {
-            radioOption.getVal().should.be.equal('val');
-        });
-    });
-
     describe('checked', function() {
         it('should properly update "control" elem "checked" attr', function() {
             radioOption
@@ -51,51 +45,6 @@ describe('radio-option', function() {
             radioOption.setMod('disabled');
             radioOption.domElem.trigger('pointerclick');
             radioOption.hasMod('checked').should.be.false;
-        });
-    });
-
-    describe('disabled', function() {
-        it('should properly update "control" elem "disabled" attr', function() {
-            radioOption
-                .setMod('disabled')
-                .elem('control').prop('disabled').should.be.true;
-
-            radioOption
-                .delMod('disabled')
-                .elem('control').prop('disabled').should.be.false;
-        });
-    });
-
-    describe('focus/blur', function() {
-        it('should have "focused" mod on focus', function() {
-            radioOption.elem('control').focus();
-            radioOption.hasMod('focused').should.be.true;
-        });
-
-        it('should not have "focused" mod on blur', function() {
-            radioOption.elem('control')
-                .focus()
-                .blur();
-            radioOption.hasMod('focused').should.be.false;
-        });
-
-        it('should be focused after "focused" mod set', function() {
-            radioOption.setMod('focused');
-            dom.containsFocus(radioOption.elem('control')).should.be.true;
-        });
-
-        it('should not set "focused" mod if it has "disabled" mod', function() {
-            radioOption
-                .setMod('disabled')
-                .setMod('focused');
-            radioOption.hasMod('focused').should.be.false;
-        });
-
-        it('should be blured after "focused" mod unset', function() {
-            radioOption
-                .setMod('focused')
-                .delMod('focused');
-            dom.containsFocus(radioOption.elem('control')).should.be.false;
         });
     });
 });

--- a/common.blocks/radio/radio.js
+++ b/common.blocks/radio/radio.js
@@ -1,3 +1,7 @@
+/**
+ * @module radio
+ */
+
 modules.define(
     'radio',
     ['i-bem__dom', 'jquery', 'dom', 'radio-option'],
@@ -5,7 +9,12 @@ modules.define(
 
 var undef;
 
-provide(BEMDOM.decl(this.name, {
+/**
+ * @exports
+ * @class radio
+ * @bem
+ */
+provide(BEMDOM.decl(this.name, /** @lends radio.prototype */{
     beforeSetMod : {
         'focused' : {
             'true' : function() {
@@ -120,6 +129,17 @@ provide(BEMDOM.decl(this.name, {
         return this._getOptionByVal(this._val);
     },
 
+    _getOptionByVal : function(val) {
+        var options = this.getOptions(),
+            i = 0, option;
+
+        while(option = options[i++]) {
+            if(option.getVal() === val) {
+                return option;
+            }
+        }
+    },
+
     _onOptionCheck : function(option) {
         var optionVal = option.getVal();
 
@@ -136,35 +156,17 @@ provide(BEMDOM.decl(this.name, {
         }
     },
 
-    _getOptionByVal : function(val) {
-        var options = this.getOptions(),
-            i = 0, option;
-
-        while(option = options[i++]) {
-            if(option.getVal() === val) {
-                return option;
-            }
-        }
-    },
-
-    _onFocus : function() {
-        this.setMod('focused');
-    },
-
-    _onBlur : function() {
-        this.delMod('focused');
+    _onOptionFocus : function(option) {
+        this.toggleMod('focused', option.hasMod('focused'));
     }
-}, {
+}, /** @lends radio */{
     live : function() {
         this
             .liveInitOnBlockInsideEvent({ modName : 'checked', modVal : true }, 'radio-option', function(e) {
                 this._onOptionCheck(e.target);
             })
-            .liveBindTo('focusin', function() {
-                this._onFocus();
-            })
-            .liveBindTo('focusout', function() {
-                this._onBlur();
+            .liveInitOnBlockInsideEvent({ modName : 'focused', modVal : '*' }, 'radio-option', function(e) {
+                this._onOptionFocus(e.target);
             });
     }
 }));

--- a/desktop.blocks/input/_autofocus/input_autofocus.js
+++ b/desktop.blocks/input/_autofocus/input_autofocus.js
@@ -5,7 +5,6 @@ provide(Input.decl({ modName : 'autofocus', modVal : true }, {
         'js' : {
             'inited' : function() {
                 this.__base.apply(this, arguments);
-
                 this.bindToDoc('keydown', this._onDocKeyDown);
             }
         },
@@ -13,7 +12,6 @@ provide(Input.decl({ modName : 'autofocus', modVal : true }, {
         'focused' : {
             'true' : function() {
                 this.__base.apply(this, arguments);
-
                 this
                     .unbindFromDoc('keydown')
                     .delMod('autofocus');

--- a/desktop.blocks/input/input.deps.js
+++ b/desktop.blocks/input/input.deps.js
@@ -1,3 +1,7 @@
-({
+[{
     shouldDeps : ['tick', 'idle']
-})
+},
+{
+    tech : 'spec.js',
+    shouldDeps : { tech : 'js', block : 'dom' }
+}]

--- a/desktop.blocks/input/input.js
+++ b/desktop.blocks/input/input.js
@@ -51,6 +51,7 @@ provide(Input.decl({
 
     /**
      * Нормализация установки фокуса для IE
+     * @override
      * @private
      */
     _focus : function() {

--- a/desktop.blocks/input/input.js
+++ b/desktop.blocks/input/input.js
@@ -51,8 +51,8 @@ provide(Input.decl({
 
     /**
      * Нормализация установки фокуса для IE
-     * @override
      * @private
+     * @override
      */
     _focus : function() {
         var input = this.elem('control')[0];

--- a/desktop.blocks/input/input.spec.js
+++ b/desktop.blocks/input/input.spec.js
@@ -1,0 +1,28 @@
+modules.define(
+    'spec',
+    ['input', 'i-bem__dom', 'jquery', 'dom', 'BEMHTML'],
+    function(provide, Input, BEMDOM, $, dom, BEMHTML) {
+
+describe('input', function() {
+    var input;
+
+    beforeEach(function() {
+        input = BEMDOM.init($(BEMHTML.apply({ block : 'input', val : 'bla' })).appendTo('body'))
+            .bem('input');
+    });
+
+    afterEach(function() {
+        BEMDOM.destruct(input.domElem);
+    });
+
+    describe('focus/blur', function() {
+        it('should be focused after "focused" mod set', function() {
+            input.setMod('focused');
+            dom.containsFocus(input.elem('control')).should.be.true;
+        });
+    });
+});
+
+provide();
+
+});

--- a/touch.blocks/input/input.js
+++ b/touch.blocks/input/input.js
@@ -6,10 +6,7 @@ provide(Input.decl({
     }
 }, {
     live : function() {
-        this.liveBindTo('control', 'input', function() {
-            this._onInputChanged();
-        });
-
+        this.liveBindTo('control', 'input', this.prototype._onInputChanged);
         return this.__base.apply(this, arguments);
     }
 }));


### PR DESCRIPTION
**WIP! DO NOT MERGE**

\cc @dfilatov 

The idea is to have a base block `base-control`, which implements common "focusable + disablable", well,.. interface ;)

The `base-control` itself never should be instantiate. It should only be used as a `baseBlock`. 

It provides reactions for `_focused`, `_disabled` modifiers, some protected methods like `_onFocus`, `_onBlur`, which are used as events handlers in _control's inheritors_. Also there are some common API methods: 
- `getName()` to get control's "name" (_returns an empty string if control doesn't have one_)
- `getVal()` to get its "value" (_returns an empty string if control doesn't have one_)

As a side notes: _I'am still not sure about the solution. It doesn't look "natural", but a least it allows to move a lot of copy and paste parts from other components, like `button`, `link`, etc. @dfilatov I need your opinion_ ;)

closes #308 
