### PR TITLE
input: fix cursor's jump to end of input when user edit text at the middle of input

### DIFF
--- a/common.blocks/input/input.js
+++ b/common.blocks/input/input.js
@@ -59,7 +59,10 @@ provide(BEMDOM.decl(this.name, {
 
         if(this._val !== val) {
             this._val = val;
-            this.elem('control').val(val);
+
+            var control = this.elem('control');
+            control.val() !== val && control.val(val);
+
             this.emit('change', data);
         }
 


### PR DESCRIPTION
Solve #388 

/cc @dfilatov @narqo 
