### PR TITLE
Border disappears in pseudobutton's disabled state

### DIFF
--- a/design/common.blocks/button/_theme/button_theme_normal.roo
+++ b/design/common.blocks/button/_theme/button_theme_normal.roo
@@ -137,7 +137,7 @@
     {
         overflow: hidden;
 
-        background: 0 !important;
+        background: 0;
 
         &:before
         {


### PR DESCRIPTION
![2014-05-28_1332](https://cloud.githubusercontent.com/assets/1333220/3102725/0137f538-e64b-11e3-8f2c-ff91d6cde453.png)
/cc @mishanga 
