### PR TITLE
checkbox(-group), radio(-group): css, refactoring

### DIFF
--- a/common.blocks/button/button.tests/simple.bemjson.js
+++ b/common.blocks/button/button.tests/simple.bemjson.js
@@ -286,55 +286,29 @@
         ] },
 
         { tag : 'p', content : [
-            { tag : 'span', content : {
+            {
                 block : 'button',
                 mods : { theme : 'normal', size : 'm', togglable : 'check' },
                 text : 'check'
-            } },
+            },
             ' ',
-            { tag : 'span', content : [
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio' },
-                    text : 'radio'
-                },
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio' },
-                    text : 'radio'
-                },
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio', checked : true },
-                    text : 'radio'
-                }
-            ] }
-        ] },
-
-        { tag : 'p', content : [
-            { tag : 'span', content : {
+            {
+                block : 'button',
+                mods : { theme : 'normal', size : 'm', togglable : 'radio' },
+                text : 'radio'
+            },
+            ' ',
+            {
                 block : 'button',
                 mods : { theme : 'normal', size : 'm', togglable : 'check', pseudo : true },
                 text : 'check'
-            } },
+            },
             ' ',
-            { tag : 'span', content : [
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio', pseudo : true },
-                    text : 'radio'
-                },
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio', pseudo : true },
-                    text : 'radio'
-                },
-                {
-                    block : 'button',
-                    mods : { theme : 'normal', size : 'm', togglable : 'radio', pseudo : true, checked : true },
-                    text : 'radio'
-                }
-            ] }
+            {
+                block : 'button',
+                mods : { theme : 'normal', size : 'm', togglable : 'radio', pseudo : true },
+                text : 'radio'
+            }
         ] }
     ]
 });

--- a/common.blocks/checkbox-group/checkbox-group.bemhtml
+++ b/common.blocks/checkbox-group/checkbox-group.bemhtml
@@ -7,21 +7,24 @@ block('checkbox-group')(
         var mods = this.mods,
             ctx = this.ctx;
 
-        return (this.ctx.options || []).map(function(option) {
-            return {
-                block : 'checkbox',
-                mods : {
-                    type : mods.type,
-                    theme : mods.theme,
-                    size : mods.size,
-                    checked : option.checked,
-                    disabled : option.disabled || mods.disabled
-                },
-                name : ctx.name,
-                val : option.val,
-                text : option.text,
-                icon : option.icon
-            }
+        return (ctx.options || []).map(function(option, i) {
+            return [
+                !!i && !mods.type && { tag : 'br' },
+                {
+                    block : 'checkbox',
+                    mods : {
+                        type : mods.type,
+                        theme : mods.theme,
+                        size : mods.size,
+                        checked : option.checked,
+                        disabled : option.disabled || mods.disabled
+                    },
+                    name : ctx.name,
+                    val : option.val,
+                    text : option.text,
+                    icon : option.icon
+                }
+            ]
         });
     })
 )

--- a/common.blocks/checkbox-group/checkbox-group.tests/simple.bemjson.js
+++ b/common.blocks/checkbox-group/checkbox-group.tests/simple.bemjson.js
@@ -134,6 +134,28 @@
             ]
         } },
 
+        { tag : 'h3', content : 'line' },
+        { tag : 'p', content : {
+            block : 'checkbox-group',
+            name : 'normal-line1',
+            mods : { theme : 'normal', size : 'm', type : 'line' },
+            options : [
+                { val : 1, text : 'first' },
+                { val : 2, text : 'second', checked : true },
+                { val : 3, text : 'third', disabled : true },
+                { val : 4, text : 'fourth', checked : true, disabled : true }
+            ]
+        } },
+        { tag : 'p', content : {
+            block : 'checkbox-group',
+            name : 'normal-line2',
+            mods : { theme : 'normal', size : 'l', type : 'line', disabled : true },
+            options : [
+                { val : 1, text : 'first' },
+                { val : 2, text : 'second', checked : true }
+            ]
+        } },
+
         { tag : 'h3', content : 'button' },
         { tag : 'p', content : {
             block : 'checkbox-group',
@@ -143,7 +165,7 @@
                 { val : 1, text : 'first' },
                 { val : 2, text : 'second', checked : true },
                 { val : 3, text : 'third', disabled : true },
-                { val : 4, text : 'fourth', disabled : true }
+                { val : 4, text : 'fourth', checked : true, disabled : true }
             ]
         } },
         { tag : 'p', content : {

--- a/common.blocks/checkbox/checkbox.tests/simple.bemjson.js
+++ b/common.blocks/checkbox/checkbox.tests/simple.bemjson.js
@@ -9,44 +9,59 @@
     content : [
 
         { tag : 'h2', content : 'default' },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            text : 'first'
-        } },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { checked : true },
-            text : 'second'
-        } },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { disabled : true },
-            text : 'third'
-        } },
+        { tag : 'p', content : [
+            {
+                block : 'checkbox',
+                text : 'first'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { checked : true },
+                text : 'second'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { disabled : true },
+                text : 'third'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { checked : true, disabled : true },
+                text : 'fourth'
+            }
+        ] },
 
         { tag : 'hr' },
 
         { tag : 'h2', content : 'simple' },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { theme : 'simple' },
-            text : 'first'
-        } },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { theme : 'simple', checked : true },
-            text : 'second'
-        } },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { theme : 'simple', checked : true, disabled : true },
-            text : 'third'
-        } },
-        { tag : 'p', content : {
-            block : 'checkbox',
-            mods : { theme : 'simple', disabled : true },
-            text : 'fourth'
-        } },
+        { tag : 'p', content : [
+            {
+                block : 'checkbox',
+                mods : { theme : 'simple' },
+                text : 'first'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { theme : 'simple', checked : true },
+                text : 'second'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { theme : 'simple', disabled : true },
+                text : 'third'
+            },
+            ' ',
+            {
+                block : 'checkbox',
+                mods : { theme : 'simple', checked : true, disabled : true },
+                text : 'fourth'
+            }
+        ] },
 
         { tag : 'h3', content : 'button' },
         { tag : 'p', content : [
@@ -175,7 +190,7 @@
             '&nbsp;',
             {
                 block : 'checkbox',
-                mods : { theme : 'normal', size : 'm', type : 'button', checked : true, disabled : true },
+                mods : { theme : 'normal', size : 'm', type : 'button', disabled : true },
                 val : 3,
                 name : 'r1',
                 text : 'third'

--- a/common.blocks/radio-group/radio-group.bemhtml
+++ b/common.blocks/radio-group/radio-group.bemhtml
@@ -4,21 +4,27 @@ block('radio-group')(
     js()(true),
 
     content()(function() {
-        return (this.ctx.options || []).map(function(option) {
-            return {
-                block : 'radio',
-                mods : {
-                    type : this.mods.type,
-                    theme : this.mods.theme,
-                    size : this.mods.size,
-                    checked : option.checked,
-                    disabled : option.disabled || this.mods.disabled
-                },
-                name : this.ctx.name,
-                val : option.val,
-                text : option.text,
-                icon : option.icon
-            }
-        }, this);
+        var mods = this.mods,
+            ctx = this.ctx;
+
+        return (ctx.options || []).map(function(option, i) {
+            return [
+                !!i && !mods.type && { tag : 'br' },
+                {
+                    block : 'radio',
+                    mods : {
+                        type : mods.type,
+                        theme : mods.theme,
+                        size : mods.size,
+                        checked : option.checked,
+                        disabled : option.disabled || mods.disabled
+                    },
+                    name : ctx.name,
+                    val : option.val,
+                    text : option.text,
+                    icon : option.icon
+                }
+            ]
+        });
     })
 )

--- a/common.blocks/radio-group/radio-group.tests/simple.bemjson.js
+++ b/common.blocks/radio-group/radio-group.tests/simple.bemjson.js
@@ -134,6 +134,30 @@
             ]
         } },
 
+        { tag : 'h3', content : 'line' },
+        { tag : 'p', content : {
+            block : 'radio-group',
+            name : 'normal-line1',
+            mods : { theme : 'normal', size : 'm', type : 'line' },
+            options : [
+                { val : 1, text : 'first' },
+                { val : 2, text : 'second', checked : true },
+                { val : 3, text : 'third', disabled : true },
+                { val : 4, text : 'fourth', checked : true, disabled : true }
+            ]
+        } },
+        { tag : 'p', content : {
+            block : 'radio-group',
+            name : 'normal-line2',
+            mods : { theme : 'normal', size : 'l', type : 'line' },
+            options : [
+                { val : 1, text : 'first' },
+                { val : 2, text : 'second', checked : true },
+                { val : 3, text : 'third', disabled : true },
+                { val : 4, text : 'fourth', checked : true, disabled : true }
+            ]
+        } },
+
         { tag : 'h3', content : 'button' },
         { tag : 'p', content : {
             block : 'radio-group',

--- a/design/common.blocks/button/_theme/button_theme_normal.roo
+++ b/design/common.blocks/button/_theme/button_theme_normal.roo
@@ -183,7 +183,6 @@
 
     &.button_disabled
     {
-        color: rgba(0, 0, 0, 0.3);
         background: rgba(0, 0, 0, 0.08);
 
         &:before
@@ -196,6 +195,11 @@
             display: block;
 
             background: #ffeba0;
+        }
+
+        .button__text
+        {
+            color: #aaa;
         }
 
         .icon
@@ -278,7 +282,8 @@
         margin-right: 0;
     }
 
-    &.button_togglable_radio
+    .checkbox-group &,
+    .radio-group &
     {
         border-radius: 0;
 
@@ -323,7 +328,5 @@
                 right: 1px;
             }
         }
-
     }
-
 }

--- a/design/common.blocks/checkbox-group/_theme/checkbox-group_theme_normal.roo
+++ b/design/common.blocks/checkbox-group/_theme/checkbox-group_theme_normal.roo
@@ -22,4 +22,22 @@
 
         white-space: nowrap;
     }
+
+    &.checkbox-group_type_line
+    {
+        &.checkbox-group_size_m .checkbox
+        {
+            margin-right: 13px;
+        }
+
+        &.checkbox-group_size_l .checkbox
+        {
+            margin-right: 15px;
+        }
+
+        .checkbox:last-child
+        {
+            margin-right: 0;
+        }
+    }
 }

--- a/design/common.blocks/radio-group/_theme/radio-group_theme_normal.roo
+++ b/design/common.blocks/radio-group/_theme/radio-group_theme_normal.roo
@@ -22,4 +22,22 @@
 
         white-space: nowrap;
     }
+
+    &.radio-group_type_line
+    {
+        &.radio-group_size_m .radio
+        {
+            margin-right: 13px;
+        }
+
+        &.radio-group_size_l .radio
+        {
+            margin-right: 15px;
+        }
+
+        .radio:last-child
+        {
+            margin-right: 0;
+        }
+    }
 }

--- a/design/common.blocks/radio/_theme/radio_theme_normal.roo
+++ b/design/common.blocks/radio/_theme/radio_theme_normal.roo
@@ -5,13 +5,6 @@
         cursor: pointer;
     }
 
-    &::after
-    {
-        display: block;
-
-        content: '';
-    }
-
     .radio__control
     {
         position: absolute;
@@ -70,6 +63,8 @@
     &.radio_disabled
     {
         cursor: default;
+
+        color: #999;
 
         .radio__box
         {

--- a/desktop.pages/normal/normal.bemjson.js
+++ b/desktop.pages/normal/normal.bemjson.js
@@ -223,6 +223,13 @@
                 },
                 ' ',
                 {
+                    block : 'radio',
+                    mods : { theme : 'normal', size : 'm', checked : true },
+                    val : 1,
+                    text : 'radio'
+                },
+                ' ',
+                {
                     block : 'checkbox',
                     mods : { theme : 'normal', size : 'm', checked : true },
                     val : 1,
@@ -292,6 +299,13 @@
                         { val : 1, text : 'first' },
                         { val : 2, text : 'second', checked : true }
                     ]
+                },
+                ' ',
+                {
+                    block : 'radio',
+                    mods : { theme : 'normal', size : 'l', checked : true },
+                    val : 1,
+                    text : 'radio'
                 },
                 ' ',
                 {


### PR DESCRIPTION
close #508 
By default radio and checkboxes inside their groups are divided by line break.
Line view (with proper margins) realized in `type_line` modifier.

![2014-05-29_1832](https://cloud.githubusercontent.com/assets/521273/3118639/245576a0-e73e-11e3-8f39-aa230b7cfda3.png)
