### PR TITLE
Disable gemini tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ env:
   matrix:
     - TEST_SCOPE: lint
     - TEST_SCOPE: specs
-    - TEST_SCOPE: gemini
+    # gemini is disabled due to many SauceLabs timeout errors.
+    # Will be re-enabled after problems are fixed.
+    #- TEST_SCOPE: gemini
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
SauceLabs too often fails with timeout. Tests are disabled to aviod
blocking other pull-requests until the solution is found.

//cc @veged 
