### PR TITLE
menu: Cross-browser compatibility

### DIFF
--- a/design/common.blocks/menu-item/_theme/menu-item_theme_normal.styl
+++ b/design/common.blocks/menu-item/_theme/menu-item_theme_normal.styl
@@ -1,7 +1,7 @@
 paddingLeft = (30 30 34 40);
 paddingVert = (3 4 5 6);
 paddingHor = (10 13 15 20);
-
+itemHeight = (24 24);
 tipSize = (14 14 15 15);
 
 .menu-item_theme_normal
@@ -70,6 +70,16 @@ for sizeVal, i in s m l xl {
         .menu__group-title ~ .menu-item_theme_normal
         {
             padding: 0 (paddingLeft[i])px;
+        }
+    }
+}
+
+for sizeVal, i in s m {
+    .menu_size_{sizeVal}
+    {
+        .menu-item_theme_normal
+        {
+            height: (itemHeight[i])px;
         }
     }
 }

--- a/design/common.blocks/menu/_theme/menu_theme_normal.styl
+++ b/design/common.blocks/menu/_theme/menu_theme_normal.styl
@@ -1,5 +1,5 @@
 fontSize = (13 13 15 15);
-lineHeight = (24 24 28 32);
+lineHeight = (23 23 28 32);
 paddingVert = (3 4 5 6);
 paddingHor = (10 13 15 20);
 


### PR DESCRIPTION
Close #854.
В FF текст размещен на 1px ниже относительно блока с размерами s и m.
![123](https://cloud.githubusercontent.com/assets/6004201/3794517/13824a7a-1bae-11e4-8175-fcaf5826dd25.png)
