### PR TITLE
select__tick: Increasing properties weight

### DIFF
--- a/common.blocks/select/__button/select__button.deps.js
+++ b/common.blocks/select/__button/select__button.deps.js
@@ -1,3 +1,0 @@
-({
-    shouldDeps : 'button'
-})

--- a/design/common.blocks/select/_theme/select_theme_normal.deps.js
+++ b/design/common.blocks/select/_theme/select_theme_normal.deps.js
@@ -1,8 +1,10 @@
 ({
+    mustDeps : [
+        { block : 'button', mods : { theme : 'normal' } }
+    ],
     shouldDeps : [
         { block : 'popup', mods : { theme : 'normal' } },
         { block : 'menu', mods : { theme : 'normal' } },
-        { block : 'button', mods : { theme : 'normal' } },
         { block : 'icon' }
     ]
 })


### PR DESCRIPTION
Из-за https://github.com/bem/bem-components/pull/905 позиционирование галочки в селекте перебилось por вместо poa.
![2014-08-06_1136](https://cloud.githubusercontent.com/assets/1333220/3823666/7e162336-1d3c-11e4-81a2-517d548ecdde.png)
