### PR TITLE
select: Incorrect select's vertical-align relative to other controls

### DIFF
--- a/design/common.blocks/select/_theme/select_theme_normal.styl
+++ b/design/common.blocks/select/_theme/select_theme_normal.styl
@@ -2,6 +2,8 @@
 {
     max-width: 100%;
 
+    vertical-align: top;
+
     .select__button
     {
         width: 100%;


### PR DESCRIPTION
Close #945 
We can't remove `display: block` from text-element because of `text-overflow: ellipsis;` fulfills only on block elements.
