### PR TITLE
popup: add deps for _target_position & _target_anchor

### DIFF
--- a/common.blocks/popup/_target/popup_target_anchor.deps.js
+++ b/common.blocks/popup/_target/popup_target_anchor.deps.js
@@ -1,0 +1,3 @@
+({
+    mustDeps : [{ mods : { target : true } }]
+})

--- a/common.blocks/popup/_target/popup_target_position.deps.js
+++ b/common.blocks/popup/_target/popup_target_position.deps.js
@@ -1,0 +1,3 @@
+({
+    mustDeps : [{ mods : { target : true } }]
+})


### PR DESCRIPTION
Because `popup_target` declaration can fall below the `popup_target_position` or `popup_target_anchor` declarations after build. 

//cc @narqo 
