### PR TITLE
progressbar: get rid of redundant applyCtx from simple theme template (close #1210)

### DIFF
--- a/design/common.blocks/progressbar/_theme/progressbar_theme_simple.bemhtml
+++ b/design/common.blocks/progressbar/_theme/progressbar_theme_simple.bemhtml
@@ -1,5 +1,5 @@
 block('progressbar').mod('theme', 'simple').content()(function() {
-    return applyCtx([
+    return [
         {
             elem : 'box',
             content : applyNext()
@@ -8,5 +8,5 @@ block('progressbar').mod('theme', 'simple').content()(function() {
             elem : 'text',
             content : this.ctx.value
         }
-    ]);
+    ];
 });


### PR DESCRIPTION
Resolves #1210
