### PR TITLE
Added srcset attribute support

### DIFF
--- a/common.blocks/image/image.bh.js
+++ b/common.blocks/image/image.bh.js
@@ -5,10 +5,16 @@ module.exports = function(bh) {
         if(typeof json.content !== 'undefined') {
             ctx.tag('span');
         } else {
+            var srcset = json.srcset || {};
+            srcset = Object.keys(srcset).map(function(size){
+                return srcset[size] + ' ' + size;
+            }).join(', ');
+
             ctx
                 .tag('img')
                 .attrs({
                     src : json.url,
+                    srcset : srcset,
                     width : json.width,
                     height : json.height,
                     alt : json.alt,


### PR DESCRIPTION
Currently, in common case `src-set` is a good solution for retina support. It is supported in the latest versions of browsers, so polyfill not required. Yes, we can use just `attrs` for it, but It is not very convenient.

If you find this idea good, i'l add to this pull request bemhtml implementation, readme, support for the attribute `sizes` and add tests.
