### PR TITLE
[menu] move specific template logic which deal with menu-item's checked mod from menu to common menu_mode

### DIFF
--- a/common.blocks/menu/_mode/menu_mode.bemhtml
+++ b/common.blocks/menu/_mode/menu_mode.bemhtml
@@ -1,0 +1,43 @@
+block('menu')
+    .match(function(){
+        return typeof this.mods.mode !== 'undefined';
+    })
+    .content()(function() {
+        var ctx = this.ctx,
+            mods = this.mods,
+            firstItem,
+            checkedItems = [];
+
+        if(ctx.content) {
+            var isValDef = typeof ctx.val !== 'undefined',
+                containsVal = function(val) {
+                    return isValDef &&
+                        (mods.mode === 'check'?
+                            ctx.val.indexOf(val) > -1 :
+                            ctx.val === val);
+                },
+                iterateItems = function(content) {
+                    var i = 0, itemOrGroup;
+                    while(itemOrGroup = content[i++]) {
+                        if(itemOrGroup.block === 'menu-item') {
+                            firstItem || (firstItem = itemOrGroup);
+                            if(containsVal(itemOrGroup.val)) {
+                                (itemOrGroup.mods = itemOrGroup.mods || {}).checked = true;
+                                checkedItems.push(itemOrGroup);
+                            }
+                        } else if(itemOrGroup.content) { // menu__group
+                            iterateItems(itemOrGroup.content);
+                        }
+                    }
+                };
+
+            if(!this.isArray(ctx.content)) throw Error('menu: content must be an array of the menu items');
+
+            iterateItems(ctx.content);
+        }
+
+    return applyNext({
+        _firstItem : firstItem,
+        _checkedItems : checkedItems
+    });
+});

--- a/common.blocks/menu/_mode/menu_mode.bh.js
+++ b/common.blocks/menu/_mode/menu_mode.bh.js
@@ -1,0 +1,43 @@
+module.exports = function(bh) {
+
+    bh.match('menu', function(ctx, json) {
+        if(!ctx.mod('mode'))
+            return;
+
+        var firstItem,
+            checkedItems = [];
+
+        if(json.content) {
+            var isValDef = typeof json.val !== 'undefined',
+                isModeCheck = ctx.mod('mode') === 'check',
+                containsVal = function(val) {
+                    return isValDef &&
+                        (isModeCheck?
+                        json.val.indexOf(val) > -1 :
+                        json.val === val);
+                },
+                iterateItems = function(content) {
+                    var i = 0, itemOrGroup;
+                    while(itemOrGroup = content[i++]) {
+                        if(itemOrGroup.block === 'menu-item') {
+                            firstItem || (firstItem = itemOrGroup);
+                            if(containsVal(itemOrGroup.val)) {
+                                (itemOrGroup.mods = itemOrGroup.mods || {}).checked = true;
+                                checkedItems.push(itemOrGroup);
+                            }
+                        } else if(itemOrGroup.content) { // menu__group
+                            iterateItems(itemOrGroup.content);
+                        }
+                    }
+                };
+
+            if(!Array.isArray(json.content)) throw Error('menu: content must be an array of the menu items');
+
+            iterateItems(json.content);
+        }
+
+        ctx
+            .tParam('firstItem', firstItem)
+            .tParam('checkedItems', checkedItems);
+    });
+};

--- a/common.blocks/menu/_mode/menu_mode_radio.bemhtml
+++ b/common.blocks/menu/_mode/menu_mode_radio.bemhtml
@@ -1,7 +1,7 @@
 block('menu')
     .mod('mode', 'radio')
     .match(this._firstItem && this._checkedItems && !this._checkedItems.length)(
-        def()(function() {
-            (this._firstItem.mods = this._firstItem.mods || {}).checked = true;
-            applyNext();
-        }));
+    content()(function() {
+        (this._firstItem.mods = this._firstItem.mods || {}).checked = true;
+        return applyNext();
+    }));

--- a/common.blocks/menu/menu.bemhtml
+++ b/common.blocks/menu/menu.bemhtml
@@ -1,45 +1,9 @@
 block('menu')(
     def()(function() {
-        var ctx = this.ctx,
-            mods = this.mods,
-            firstItem,
-            checkedItems = [];
-
-        if(ctx.content) {
-            var isValDef = typeof ctx.val !== 'undefined',
-                containsVal = function(val) {
-                    return isValDef &&
-                        (mods.mode === 'check'?
-                            ctx.val.indexOf(val) > -1 :
-                            ctx.val === val);
-                },
-                iterateItems = function(content) {
-                    var i = 0, itemOrGroup;
-                    while(itemOrGroup = content[i++]) {
-                        if(itemOrGroup.block === 'menu-item') {
-                            firstItem || (firstItem = itemOrGroup);
-                            if(containsVal(itemOrGroup.val)) {
-                                (itemOrGroup.mods = itemOrGroup.mods || {}).checked = true;
-                                checkedItems.push(itemOrGroup);
-                            }
-                        } else { // menu__group
-                            iterateItems(itemOrGroup.content);
-                        }
-                    }
-                };
-
-            if(!this.isArray(ctx.content)) throw Error('menu: content must be an array of the menu items');
-
-            iterateItems(ctx.content);
-        }
-
-        this._firstItem = firstItem;
-        this._checkedItems = checkedItems;
-
         applyNext({
             _menuMods : {
-                theme : mods.theme,
-                disabled : mods.disabled
+                theme : this.mods.theme,
+                disabled : this.mods.disabled
             }
         });
     }),

--- a/common.blocks/menu/menu.bh.js
+++ b/common.blocks/menu/menu.bh.js
@@ -1,6 +1,6 @@
 module.exports = function(bh) {
 
-    bh.match('menu', function(ctx, json) {
+    bh.match('menu', function(ctx) {
         var menuMods = {
             theme : ctx.mod('theme'),
             disabled : ctx.mod('disabled')
@@ -14,41 +14,5 @@ module.exports = function(bh) {
         var attrs = { role : 'menu' };
         ctx.mod('disabled') || (attrs.tabindex = 0);
         ctx.attrs(attrs);
-
-        var firstItem,
-            checkedItems = [];
-
-        if(json.content) {
-            var isValDef = typeof json.val !== 'undefined',
-                isModeCheck = ctx.mod('mode') === 'check',
-                containsVal = function(val) {
-                    return isValDef &&
-                        (isModeCheck?
-                            json.val.indexOf(val) > -1 :
-                            json.val === val);
-                },
-                iterateItems = function(content) {
-                    var i = 0, itemOrGroup;
-                    while(itemOrGroup = content[i++]) {
-                        if(itemOrGroup.block === 'menu-item') {
-                            firstItem || (firstItem = itemOrGroup);
-                            if(containsVal(itemOrGroup.val)) {
-                                (itemOrGroup.mods = itemOrGroup.mods || {}).checked = true;
-                                checkedItems.push(itemOrGroup);
-                            }
-                        } else { // menu__group
-                            iterateItems(itemOrGroup.content);
-                        }
-                    }
-                };
-
-            if(!Array.isArray(json.content)) throw Error('menu: content must be an array of the menu items');
-
-            iterateItems(json.content);
-        }
-
-        ctx
-            .tParam('firstItem', firstItem)
-            .tParam('checkedItems', checkedItems);
     });
 };

--- a/common.blocks/menu/menu.deps.js
+++ b/common.blocks/menu/menu.deps.js
@@ -10,7 +10,7 @@
 },
 {
     tech : 'spec.js',
-    mustDeps : { tech : 'bemhtml', block : 'menu' }
+    mustDeps : { tech : 'bemhtml', block : 'menu', mods : { mode : 'radio' } }
 },
 {
     tech : 'tmpl-spec.js',


### PR DESCRIPTION
iterate through content only within all menu_mode_*
do it in `content` mode instead of `def`
use applyNext instead of setting global ctx properties

resolves #1513  #1516 
