### PR TITLE
Load jquery from cdnjs.cloudflare.com instead of yastatic.net

### DIFF
--- a/.enb/make.js
+++ b/.enb/make.js
@@ -377,7 +377,8 @@ function getTestLevels(platform) {
 function getSpecLevels(platform) {
     return [].concat(
         { path : path.join('libs', 'bem-pr', 'spec.blocks'), check : false },
-        getSourceLevels(platform)
+        getSourceLevels(platform),
+        'specs.blocks'
     );
 }
 

--- a/specs.blocks/jquery/__config/jquery__config.js
+++ b/specs.blocks/jquery/__config/jquery__config.js
@@ -1,0 +1,8 @@
+modules.define('jquery__config', function(provide) {
+
+provide({
+    url : 'http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js'
+});
+
+});
+


### PR DESCRIPTION
Trying to fix yastatic.net + CORS / HSTS problems in the current phantomjs runtime.

Currently all our specs fail with errors like the one below:

```
Failed to start mocha: Init timeout
Error loading resource http://yastatic.net/jquery/2.1.3/jquery.min.js (5). Details: Operation canceled
Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file:///home/travis/build/bem/bem-components/node_modules/enb-bem-specs/node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee. Domains, protocols and ports must match.
```

It seems that HSTS headers are the reason. But it's not clear, how should it be fixed as there are several bugs in the phantomjs related projects on the github, and non of the solution (e.g. use https-only or downgrade phantomjs to 1.9.7) seems doesn't work
