### PR TITLE
checkbox: Doesn't work in MS Edge

### DIFF
--- a/design/common.blocks/checkbox/_theme/checkbox_theme_islands.styl
+++ b/design/common.blocks/checkbox/_theme/checkbox_theme_islands.styl
@@ -26,7 +26,6 @@
         position: relative;
 
         display: inline-block;
-        pointer-events: none; // fix #1472 (see ftlabs/fastclick#351 for details)
 
         border-radius: 3px;
         background: rgba(0, 0, 0, 0.2);
@@ -198,4 +197,10 @@
             margin-right: 0;
         }
     }
+}
+
+/* hack for Safari only */
+_::-webkit-full-page-media, _:future, :root .checkbox_theme_islands .checkbox__box
+{
+    pointer-events: none; // NOTE: Fix #1472 and #1590
 }

--- a/design/common.blocks/checkbox/_theme/checkbox_theme_simple.styl
+++ b/design/common.blocks/checkbox/_theme/checkbox_theme_simple.styl
@@ -1,5 +1,7 @@
 .checkbox_theme_simple
 {
+    position: relative;
+
     .checkbox__control
     {
         position: absolute;
@@ -11,7 +13,6 @@
     .checkbox__box
     {
         display: inline-block;
-        pointer-events: none; // fix #1472 (see ftlabs/fastclick#351 for details)
 
         &:before
         {
@@ -43,4 +44,10 @@
 
         background: #fff7db;
     }
+}
+
+/* hack for Safari only */
+_::-webkit-full-page-media, _:future, :root .checkbox_theme_islands .checkbox__box
+{
+    pointer-events: none; // NOTE: Fix #1472 and #1590
 }


### PR DESCRIPTION
Closes #1590 

@narqo I tried to remove `position: relative`property, but checkbox doesn't work without it in Safari.
