### PR TITLE
Fix select_mode_check and checkedText when single option selected

### DIFF
--- a/common.blocks/menu-item/menu-item.js
+++ b/common.blocks/menu-item/menu-item.js
@@ -71,6 +71,14 @@ provide(BEMDOM.decl(this.name, /** @lends menu-item.prototype */{
         return this.params.text || this.domElem.text();
     },
 
+    /**
+     * Returns item text for checked state
+     * @returns {String}
+     */
+    getCheckedText : function() {
+        return this.params.checkedText || this.getText();
+    },
+
     _onPointerOver : function() {
         this.setMod('hovered');
     },

--- a/common.blocks/select/_mode/select_mode_check.bemhtml
+++ b/common.blocks/select/_mode/select_mode_check.bemhtml
@@ -9,7 +9,7 @@ block('select').mod('mode', 'check')(
             {
                 elem : 'text',
                 content : checkedOptions.length === 1?
-                    checkedOptions[0].text :
+                    checkedOptions[0].checkedText || checkedOptions[0].text :
                     checkedOptions.reduce(function(res, option) {
                         return res + (res? ', ' : '') + (option.checkedText || option.text);
                     }, '') ||

--- a/common.blocks/select/_mode/select_mode_check.bh.js
+++ b/common.blocks/select/_mode/select_mode_check.bh.js
@@ -28,7 +28,7 @@ module.exports = function(bh) {
         ctx.content({
             elem : 'text',
             content : checkedOptions.length === 1?
-                checkedOptions[0].text :
+                checkedOptions[0].checkedText || checkedOptions[0].text :
                 checkedOptions.reduce(function(res, option) {
                     return res + (res? ', ' : '') + (option.checkedText || option.text);
                 }, '') ||

--- a/common.blocks/select/_mode/select_mode_check.js
+++ b/common.blocks/select/_mode/select_mode_check.js
@@ -32,9 +32,9 @@ provide(Select.decl({ modName : 'mode', modVal : 'check' }, /** @lends select.pr
             .toggleMod('checked', true, '', !!checkedItems.length)
             .setText(
                 checkedItems.length === 1?
-                    checkedItems[0].getText() : // one checked
+                    checkedItems[0].getCheckedText() : // one checked
                     checkedItems.reduce(function(res, item) { // many checked
-                        return res + (res? ', ' : '') + (item.params.checkedText || item.getText());
+                        return res + (res? ', ' : '') + item.getCheckedText();
                     }, '') ||
                         this.params.text); // none checked
     },

--- a/common.blocks/select/_mode/select_mode_check.spec.js
+++ b/common.blocks/select/_mode/select_mode_check.spec.js
@@ -73,7 +73,7 @@ describe('select_mode_check', function() {
             button.getText().should.be.equal('first, sec');
 
             select.setVal([2]);
-            button.getText().should.be.equal('second');
+            button.getText().should.be.equal('sec');
 
             select.setVal([]);
             button.getText().should.be.equal('text');

--- a/common.blocks/select/select.tmpl-specs/41-check-default-single-checked-checkedText.bemjson.js
+++ b/common.blocks/select/select.tmpl-specs/41-check-default-single-checked-checkedText.bemjson.js
@@ -1,0 +1,11 @@
+({
+    block : 'select',
+    mods : { mode : 'check', theme : 'islands' },
+    name : 'select',
+    text : 'select-check',
+    val : [1],
+    options : [
+        { val : 1, text : 'first', checkedText : 'checkedText' },
+        { val : 2, text : 'second' }
+    ]
+})

--- a/common.blocks/select/select.tmpl-specs/41-check-default-single-checked-checkedText.html
+++ b/common.blocks/select/select.tmpl-specs/41-check-default-single-checked-checkedText.html
@@ -1,0 +1,10 @@
+<div class="select select_mode_check select_theme_islands i-bem" data-bem="{&quot;select&quot;:{&quot;name&quot;:&quot;select&quot;,&quot;text&quot;:&quot;select-check&quot;}}">
+    <input class="select__control" type="hidden" name="select" value="1" />
+    <button aria-labelledby="" aria-multiselectable="true" class="button button_theme_islands button_checked button__control select__button i-bem" data-bem="{&quot;button&quot;:{}}" role="listbox" aria-owns="{{\w+\s\w+}}" type="button"><span class="button__text" id>checkedText</span><span class="icon select__tick"></span></button>
+    <div aria-hidden="true" class="popup popup_theme_islands popup_autoclosable popup_target_anchor i-bem" data-bem="{&quot;popup&quot;:{&quot;directions&quot;:[&quot;bottom-left&quot;,&quot;bottom-right&quot;,&quot;top-left&quot;,&quot;top-right&quot;]}}">
+        <div class="menu menu_theme_islands menu_mode_check menu__control select__menu i-bem" data-bem="{&quot;menu&quot;:{}}">
+            <div id aria-checked="true" class="menu-item menu-item_checked menu-item_theme_islands i-bem" data-bem="{&quot;menu-item&quot;:{&quot;checkedText&quot;:&quot;checkedText&quot;,&quot;val&quot;:1}}" role="option">first</div>
+            <div id aria-checked="false" class="menu-item menu-item_theme_islands i-bem" data-bem="{&quot;menu-item&quot;:{&quot;val&quot;:2}}" role="option">second</div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Select must use `checkedText` option always.

Without this fix `select_mode_check` uses `text` option instead of `checkedText` when single option selected.
