### PR TITLE
Fixed checked button double right border in control group

### DIFF
--- a/design/common.blocks/button/_theme/button_theme_islands.styl
+++ b/design/common.blocks/button/_theme/button_theme_islands.styl
@@ -312,6 +312,7 @@ ctx = '.button_theme_islands'
 
 .control-group
 {
+    .button_checked + {ctx}:before
     .radio_checked + .radio {ctx}:before
     .checkbox_checked + .checkbox {ctx}:before
     {


### PR DESCRIPTION
Checked button in a control group has double right border due to `right: 1px` in [button_theme_islands.styl#L337](https://github.com/bem/bem-components/blob/34a3df7/design/common.blocks/button/_theme/button_theme_islands.styl#L337). The rule seems to be excessive, so this PR removes it.

![checked-double-border-bug](https://cloud.githubusercontent.com/assets/1467392/11182823/c632d4d6-8c7e-11e5-84d0-bcbcc0ccf97b.png)
