### PR TITLE
dropdown_switcher_link: Fix deps

### DIFF
--- a/common.blocks/dropdown/_switcher/dropdown_switcher_link.deps.js
+++ b/common.blocks/dropdown/_switcher/dropdown_switcher_link.deps.js
@@ -5,6 +5,6 @@
     tech : 'spec.js',
     mustDeps : [
         { tech : 'bemhtml', block : 'dropdown', mods : { switcher : 'link' } },
-        { tech : 'bemhtml', block : { block : 'link', mods : { pseudo : true } } }
+        { tech : 'bemhtml', block : 'link', mods : { pseudo : true } }
     ]
 }]


### PR DESCRIPTION
@veged is it just a typo or you wanted just templates of `link_pseudo` without templates of `link` itself?

Closes #1732
