### PR TITLE
Fixed left border of button in control group in old IE.

### DIFF
--- a/design/desktop.blocks/button/_theme/button_theme_islands.ie.styl
+++ b/design/desktop.blocks/button/_theme/button_theme_islands.ie.styl
@@ -121,7 +121,8 @@ checkedPressedColor = #fee481;
         }
     }
 
-    > :first-child .button_theme_islands
+    > :first-child .button_theme_islands,
+    > .button_theme_islands:first-child
     {
         border-left-width: 1px;
 


### PR DESCRIPTION
Same problem as in #1723 but in older IE.

Before:
![leftborderie8-before](https://cloud.githubusercontent.com/assets/1467392/12271813/2042c848-b96e-11e5-9dd7-147be236f5b0.png)

After:
![leftborderie8-after](https://cloud.githubusercontent.com/assets/1467392/12271818/240066f2-b96e-11e5-9e17-d5835c02e736.png)
