### PR TITLE
Fixed links in showcase

### DIFF
--- a/desktop.pages/showcase/showcase.bemjson.js
+++ b/desktop.pages/showcase/showcase.bemjson.js
@@ -5,7 +5,7 @@ var addLinkToDoc = function(blockName, hash, text) {
         {
             block : 'link',
             mods : { theme : 'islands', size : 'l', type : 'docs' },
-            url : '../../common.blocks/' + blockName + '/' + blockName + '.ru.md' + (hash? hash : ''),
+            url : 'https://github.com/bem/bem-components/blob/v2/common.blocks/' + blockName + '/' + blockName + '.ru.md' + (hash? hash : ''),
             content : text || blockName
         },
         { tag : 'br'}


### PR DESCRIPTION
In [showcase](http://bem.github.io/reports/5748/showcase/showcase.html) links are going to

> http://bem.github.io/reports/common.blocks/button/button.ru.md#Модификатор-view

which is 404. There is no `common.blocks` in [bem/reports](https://github.com/bem/reports). I believe it was intended to link to urls like

> https://github.com/bem/bem-components/blob/v2/common.blocks/button/button.ru.md
