### PR TITLE
Fixed links to CHANGELOG.md and MIGRATION.md in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Contents
 
 **Additional information**
 
--   [Changelog](/CHANGELOG.en.md)
--   [Migration to future versions](/MIGRATION.en.md)
+-   [Changelog](/CHANGELOG.md)
+-   [Migration to future versions](/MIGRATION.md)
 
 <a name="levels"></a>
 


### PR DESCRIPTION
There is no `.en` part in english versions of documents.
