### PR TITLE
packaging: Provide reasonable ignores

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*.blocks/*/*.tests
+*.blocks/*/*.tmpl-specs
+*.blocks/*/*.spec.js

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,26 @@
 {
   "name": "bem-components",
-  "version": "3.0.0",
   "description": "BEM Components Library",
-  "bugs": "https://github.com/bem/bem-components/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bem/bem-components.git"
+  },
+  "homepage": "https://bem.info/libs/bem-components/",
   "main": "",
+  "keywords": [
+    "bem",
+    "components",
+    "controls",
+    "ui"
+  ],
   "ignore": [
-    ".bem/cache",
-    ".enb/tmp",
-    "node_modules",
-    "libs"
+    "*",
+    "!common.blocks",
+    "!desktop.blocks",
+    "!touch.blocks",
+    "!design",
+    "!*.md",
+    "!LICENSE.txt"
   ],
   "dependencies": {
     "bem-core": "3.0.1"
@@ -16,6 +28,5 @@
   "devDependencies": {
     "bem-pr": "~0.13.0"
   },
-  "license": "MPL-2.0",
-  "private": true
+  "license": "MPL-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "README.ru.md"
   ],
   "dependencies": {},
+  "peerDependency": {
+    "bem-core": "^3.0.1"
+  },
   "devDependencies": {
     "bem-naming": "^1.0.1",
     "bem-walk": "^1.0.0-1",

--- a/package.json
+++ b/package.json
@@ -4,16 +4,28 @@
   "name": "bem-components",
   "version": "3.0.0",
   "description": "BEM Components Library",
+  "homepage": "https://bem.info/libs/bem-components/",
   "repository": {
     "type": "git",
     "url": "git://github.com/bem/bem-components.git"
   },
+  "bugs": "https://github.com/bem/bem-components/issues",
   "keywords": [
-    "bem"
+    "bem",
+    "components",
+    "controls",
+    "ui"
   ],
   "engines": {
     "node": ">=4"
   },
+  "files": [
+    "common.blocks",
+    "desktop.blocks",
+    "touch.blocks",
+    "design",
+    "README.ru.md"
+  ],
   "dependencies": {},
   "devDependencies": {
     "bem-naming": "^1.0.1",
@@ -45,7 +57,6 @@
     "jshint-groups": "^0.8.0",
     "stylus": "^0.54.5"
   },
-  "optionalDependencies": {},
   "scripts": {
     "start": "magic server",
     "deps": "bower i",


### PR DESCRIPTION
As we now publish releases with precompiled stylus files to `npm` and `bower` there was request to get rid of all useless files.

Closes #1844

Based on
- https://docs.npmjs.com/files/package.json
- https://github.com/bower/spec/blob/master/json.md
