### PR TITLE
Force blur on disable to prevent "document.activeElement = button_disabled" in FF

### DIFF
--- a/common.blocks/control/control.js
+++ b/common.blocks/control/control.js
@@ -100,9 +100,9 @@ provide(BEMDOM.decl(this.name, /** @lends control.prototype */{
     },
 
     _blur : function() {
-        dom.isFocusable(this.elem('control'))?
-            this.elem('control').blur() :
-            this._onBlur();
+        // force both `blur` and `_onBlur` for FF which can have disabled element as `document.activeElement`
+        this.elem('control').blur();
+        this._onBlur();
     }
 }, /** @lends control */{
     live : function() {


### PR DESCRIPTION
cc @narqo @tadatuta 

FF keeps disabled button as `document.activeElement` if it was focused before.

<!--TECHNICAL_SECTION_DO_NOT_EDIT-->

---

<!--SECTION_BEGIN:showcase-->

Showcase is [available](http://bem.github.io/reports/6241/showcase/showcase.html)

<!--SECTION_END:showcase-->

<!--SECTION_BEGIN:error_report-->

Report is [available](http://bem.github.io/reports/6241/gemini-report)

<!--SECTION_END:error_report-->

<!--TECHNICAL_SECTION_DO_NOT_EDIT-->
