### PR TITLE
modal_autoclosable: subscribe to `pointerclick` on next tick to prevent being closed immediately

### DIFF
--- a/common.blocks/modal/_autoclosable/modal_autoclosable.js
+++ b/common.blocks/modal/_autoclosable/modal_autoclosable.js
@@ -18,9 +18,11 @@ provide(Modal.decl({ modName : 'autoclosable', modVal : true }, /** @lends modal
             'true' : function() {
                 this.__base.apply(this, arguments);
 
-                this
-                    .bindTo('pointerclick', this._onPointerClick)
-                    ._popup.on({ modName : 'visible', modVal : '' }, this._onPopupHide, this);
+                this.nextTick(function() {
+                    this.bindTo('pointerclick', this._onPointerClick);
+                });
+
+                this._popup.on({ modName : 'visible', modVal : '' }, this._onPopupHide, this);
             },
 
             '' : function() {

--- a/common.blocks/modal/_autoclosable/modal_autoclosable.spec.js
+++ b/common.blocks/modal/_autoclosable/modal_autoclosable.spec.js
@@ -19,9 +19,12 @@ describe('modal_autoclosable', function() {
         modal.hasMod('visible').should.be.true;
     });
 
-    it('should be closed on click inside modal, but outside __content', function() {
-        doPointerClick(modal.domElem);
-        modal.hasMod('visible').should.be.false;
+    it('should be closed on click inside modal, but outside __content', function(done) {
+        setTimeout(function() {
+            doPointerClick(modal.domElem);
+            modal.hasMod('visible').should.be.false;
+            done();
+        }, 50);
     });
 
     it('should be closed on click outside modal', function(done) {


### PR DESCRIPTION
<!--TECHNICAL_SECTION_DO_NOT_EDIT-->
---
<!--SECTION_BEGIN:showcase-->
Showcase is [available](http://bem.github.io/reports/6427/showcase/showcase.html)
<!--SECTION_END:showcase-->
<!--TECHNICAL_SECTION_DO_NOT_EDIT-->