### PR TITLE
menu__item: Fix arrow/pointer highlight behavior

### DIFF
--- a/common.blocks/menu/__item/menu__item.js
+++ b/common.blocks/menu/__item/menu__item.js
@@ -71,7 +71,7 @@ provide(bemDom.declElem('menu', 'item', /** @lends menu__item.prototype */{
         return this.params.text || this.domElem.text();
     },
 
-    _onPointerOver : function() {
+    _onPointerMove : function() {
         this.setMod('hovered');
     },
 
@@ -88,7 +88,7 @@ provide(bemDom.declElem('menu', 'item', /** @lends menu__item.prototype */{
         var ptp = this.prototype;
 
         this._domEvents()
-            .on('pointerover', ptp._onPointerOver)
+            .on('pointermove', ptp._onPointerMove)
             .on('pointerclick', ptp._onPointerClick);
     }
 }));

--- a/common.blocks/menu/__item/menu__item.spec.js
+++ b/common.blocks/menu/__item/menu__item.spec.js
@@ -17,10 +17,10 @@ describe('menu__item', function() {
     });
 
     describe('hovered', function() {
-        it('should be hovered/unhovered on pointerover/pointerleave', function() {
+        it('should be hovered/unhovered on pointermove/pointerleave', function() {
             menuItem.hasMod('hovered').should.be.false;
 
-            menuItem.domElem.trigger('pointerover');
+            menuItem.domElem.trigger('pointermove');
             menuItem.hasMod('hovered').should.be.true;
 
             menuItem.domElem.trigger('pointerleave');


### PR DESCRIPTION
before:
highlight menu__item with cursor then use arrows then move the cursor again —  no highlight
![menu__item_before](https://user-images.githubusercontent.com/1813468/28727986-8a0ee73a-73cf-11e7-9fba-4511b4437c78.gif)

after:
![menu__item_after](https://user-images.githubusercontent.com/1813468/28728144-2c16e14a-73d0-11e7-8342-efc0b11ba909.gif)


