### PR TITLE
popup_target_anchor: Change calc logic (#2051)

### DIFF
--- a/common.blocks/popup/_target/popup_target_anchor.js
+++ b/common.blocks/popup/_target/popup_target_anchor.js
@@ -144,14 +144,14 @@ provide(Popup.decl({ modName : 'target', modVal : 'anchor' }, /** @lends popup.p
             anchorRight = anchorLeft + anchor.outerWidth(),
             anchorBottom = anchorTop + anchor.outerHeight(),
             direction = this.getMod('direction'),
-            vertBorder = Math.floor(this._checkMainDirection(direction, 'top') ||
+            vertBorder = this._checkMainDirection(direction, 'top') ||
                     this._checkSecondaryDirection(direction, 'top')?
                 anchorTop :
-                anchorBottom),
-            horizBorder = Math.floor(this._checkMainDirection(direction, 'left') ||
+                anchorBottom,
+            horizBorder = this._checkMainDirection(direction, 'left') ||
                     this._checkSecondaryDirection(direction, 'left')?
                 anchorLeft :
-                anchorRight),
+                anchorRight,
             res = true;
 
         this._anchorParents.each(function() {
@@ -167,14 +167,14 @@ provide(Popup.decl({ modName : 'target', modVal : 'anchor' }, /** @lends popup.p
                 var parentOffset = parent.offset();
 
                 if(checkOverflowY) {
-                    var parentTopOffset = Math.floor(parentOffset.top);
+                    var parentTopOffset = parentOffset.top;
                     if(vertBorder < parentTopOffset || parentTopOffset + parent.outerHeight() < vertBorder) {
                         return res = false;
                     }
                 }
 
                 if(checkOverflowX) {
-                    var parentLeftOffset = Math.floor(parentOffset.left);
+                    var parentLeftOffset = parentOffset.left;
                     return res = !(
                         horizBorder < parentLeftOffset ||
                         parentLeftOffset + parent.outerWidth() < horizBorder);


### PR DESCRIPTION
У себя столкнулись с проблемой отображения popup_target_anchor "внутри" popup_target_position.
(контекстное меню). Дочерние элементы по необъяснимой причине на паре машин не отображались.

Убрал floor, расчёты стали правильные (до этого из-за floor разница в `0.5px` блокировала отображение). На v6 точно такой же фикс оказался.